### PR TITLE
fix: handle empty dict as falsy in JSON body encoding

### DIFF
--- a/skills/matrix-communication/SKILL.md
+++ b/skills/matrix-communication/SKILL.md
@@ -434,7 +434,7 @@ Thanks to everyone who contributed."
 
 ## Bash Quoting
 
-**Important:** When message ends with `!`, use single quotes or `$'...'` to avoid bash history expansion adding backslashes.
+**Important:** When message ends with !, use single quotes or $'...' to avoid bash history expansion adding backslashes.
 
 ```bash
 # WRONG - bash escapes !" to \!

--- a/skills/matrix-communication/scripts/matrix-edit.py
+++ b/skills/matrix-communication/scripts/matrix-edit.py
@@ -49,7 +49,7 @@ def matrix_request(config: dict, method: str, endpoint: str, data: dict = None) 
         "Content-Type": "application/json"
     }
 
-    body = json.dumps(data).encode() if data else None
+    body = json.dumps(data).encode() if data is not None else None
     req = urllib.request.Request(url, data=body, headers=headers, method=method)
 
     try:

--- a/skills/matrix-communication/scripts/matrix-react.py
+++ b/skills/matrix-communication/scripts/matrix-react.py
@@ -52,7 +52,7 @@ def matrix_request(config: dict, method: str, endpoint: str, data: dict = None) 
         "Content-Type": "application/json"
     }
 
-    body = json.dumps(data).encode() if data else None
+    body = json.dumps(data).encode() if data is not None else None
     req = urllib.request.Request(url, data=body, headers=headers, method=method)
 
     try:

--- a/skills/matrix-communication/scripts/matrix-redact.py
+++ b/skills/matrix-communication/scripts/matrix-redact.py
@@ -45,7 +45,7 @@ def matrix_request(config: dict, method: str, endpoint: str, data: dict = None) 
         "Content-Type": "application/json"
     }
 
-    body = json.dumps(data).encode() if data else None
+    body = json.dumps(data).encode() if data is not None else None
     req = urllib.request.Request(url, data=body, headers=headers, method=method)
 
     try:
@@ -84,7 +84,7 @@ def redact_message(config: dict, room_id: str, event_id: str, reason: str = None
         config,
         "PUT",
         f"/rooms/{urllib.parse.quote(room_id, safe='')}/redact/{encoded_event_id}/{txn_id}",
-        data if data else None
+        data  # Always pass dict, even if empty - {} is falsy but Matrix needs JSON body
     )
 
 

--- a/skills/matrix-communication/scripts/matrix-send.py
+++ b/skills/matrix-communication/scripts/matrix-send.py
@@ -59,7 +59,7 @@ def matrix_request(config: dict, method: str, endpoint: str, data: dict = None) 
         "Content-Type": "application/json"
     }
 
-    body = json.dumps(data).encode() if data else None
+    body = json.dumps(data).encode() if data is not None else None
     req = urllib.request.Request(url, data=body, headers=headers, method=method)
 
     try:


### PR DESCRIPTION
## Summary

- Fix `M_NOT_JSON` error when sending requests with empty JSON body (e.g., redact without reason)
- Fix skill loader parsing issue with backtick patterns in SKILL.md

## Problem

In Python, empty dict `{}` is **falsy**:
```python
>>> bool({})
False
>>> {} if {} else None
None
```

This caused `if data else None` to return `None` when `data={}`, resulting in no JSON body being sent. Matrix API returns `M_NOT_JSON` error.

## Changes

1. **Scripts** (`matrix-redact.py`, `matrix-edit.py`, `matrix-send.py`, `matrix-react.py`):
   - Changed `if data else None` → `if data is not None else None`

2. **matrix-redact.py**:
   - Also fixed `data if data else None` → `data` in the function call

3. **SKILL.md**:
   - Removed backticks around `!` that triggered skill loader command parsing

## Test plan

- [ ] Test `matrix-redact.py` without `--reason` flag (empty body case)
- [ ] Verify skill loads without "Bash command failed" error