### PR TITLE
fix: clean backslash from room IDs in E2EE scripts

### DIFF
--- a/skills/matrix-communication/scripts/matrix-edit-e2ee.py
+++ b/skills/matrix-communication/scripts/matrix-edit-e2ee.py
@@ -260,10 +260,11 @@ def main():
 
     config = load_config()
     message = clean_message(args.message)
+    room = clean_message(args.room)  # Room IDs also start with ! and need cleaning
     if not args.no_prefix and config.get("bot_prefix"):
         message = add_bot_prefix(message, config["bot_prefix"])
 
-    result = asyncio.run(edit_message_e2ee(config, args.room, args.event_id, message, args.debug))
+    result = asyncio.run(edit_message_e2ee(config, room, args.event_id, message, args.debug))
 
     if "error" in result:
         if args.json: print(json.dumps(result))

--- a/skills/matrix-communication/scripts/matrix-read-e2ee.py
+++ b/skills/matrix-communication/scripts/matrix-read-e2ee.py
@@ -407,10 +407,11 @@ def main():
     args = parser.parse_args()
 
     config = load_config()
+    room = args.room.replace('\\!', '!')  # Clean bash history expansion artifact
 
     messages = asyncio.run(read_messages_e2ee(
         config=config,
-        room=args.room,
+        room=room,
         limit=args.limit,
         request_keys=args.request_keys,
         backup_passphrase=args.backup,

--- a/skills/matrix-communication/scripts/matrix-send-e2ee.py
+++ b/skills/matrix-communication/scripts/matrix-send-e2ee.py
@@ -566,8 +566,9 @@ def main():
 
     config = load_config()
 
-    # Clean message from bash escaping artifacts
+    # Clean message and room from bash escaping artifacts
     message = clean_message(args.message)
+    room = clean_message(args.room)  # Room IDs also start with ! and need cleaning
 
     # Add bot prefix if configured (unless --no-prefix or emote)
     if not args.no_prefix and not args.emote and config.get("bot_prefix"):
@@ -576,7 +577,7 @@ def main():
     # Run async send
     result = asyncio.run(send_message_e2ee(
         config=config,
-        room=args.room,
+        room=room,
         message=message,
         emote=args.emote,
         thread_id=args.thread,


### PR DESCRIPTION
## Summary

Room IDs start with `!` which can be escaped to `\!` by bash history expansion when using double quotes. The `clean_message` function already handles this for messages but wasn't applied to room arguments.

## Problem

```bash
# This fails because bash escapes ! to \!
uv run matrix-send-e2ee.py "!roomid:server" "message"
# Error: No such room with id \!roomid:server found
```

## Fix

Apply the same `\!` → `!` cleaning to room arguments in E2EE scripts.

## Affected scripts

- matrix-send-e2ee.py
- matrix-edit-e2ee.py  
- matrix-read-e2ee.py

## Test plan

- [ ] Test `matrix-send-e2ee.py` with room ID in double quotes
- [ ] Verify `\!` is cleaned from room ID before nio receives it