### PR TITLE
fix(skill): use ${CLAUDE_SKILL_DIR} for script paths

### DIFF
--- a/.github/workflows/eval-validate.yml
+++ b/.github/workflows/eval-validate.yml
@@ -11,4 +11,3 @@ permissions:
 jobs:
   eval-validate:
     uses: netresearch/skill-repo-skill/.github/workflows/eval-validate.yml@main
-

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,7 +19,7 @@ commands/work-update.md # /work-update slash command template
 docs/ARCHITECTURE.md    # System architecture overview
 Build/Scripts/          # CI validation scripts (version checks)
 scripts/verify-harness.sh   # Harness maturity checker
-.github/workflows/      # CI: lint, release, harness-verify, auto-merge-deps
+.github/workflows/      # CI: lint, release, harness-verify, auto-merge-deps, eval-validate
 ```
 
 ## Commands

--- a/skills/matrix-communication/SKILL.md
+++ b/skills/matrix-communication/SKILL.md
@@ -22,36 +22,36 @@ ROOM: name (`test`), ID (`!abc:server`), or alias (`#room:server`).
 
 ```bash
 # Send (E2EE)
-set +H && uv run skills/matrix-communication/scripts/matrix-send-e2ee.py ROOM "message"
-uv run skills/matrix-communication/scripts/matrix-send-e2ee.py ROOM "message" --no-prefix
-uv run skills/matrix-communication/scripts/matrix-send-e2ee.py ROOM "is deploying" --emote
-uv run skills/matrix-communication/scripts/matrix-send-e2ee.py ROOM "reply" --thread '$rootEventId'
-uv run skills/matrix-communication/scripts/matrix-send-e2ee.py ROOM "reply" --reply '$eventId'
+set +H && uv run ${CLAUDE_SKILL_DIR}/scripts/matrix-send-e2ee.py ROOM "message"
+uv run ${CLAUDE_SKILL_DIR}/scripts/matrix-send-e2ee.py ROOM "message" --no-prefix
+uv run ${CLAUDE_SKILL_DIR}/scripts/matrix-send-e2ee.py ROOM "is deploying" --emote
+uv run ${CLAUDE_SKILL_DIR}/scripts/matrix-send-e2ee.py ROOM "reply" --thread '$rootEventId'
+uv run ${CLAUDE_SKILL_DIR}/scripts/matrix-send-e2ee.py ROOM "reply" --reply '$eventId'
 
 # Read (E2EE)
-uv run skills/matrix-communication/scripts/matrix-read-e2ee.py ROOM --limit 10
-uv run skills/matrix-communication/scripts/matrix-read-e2ee.py ROOM --limit 20 --json
-uv run skills/matrix-communication/scripts/matrix-read-e2ee.py ROOM --limit 10 --request-keys
+uv run ${CLAUDE_SKILL_DIR}/scripts/matrix-read-e2ee.py ROOM --limit 10
+uv run ${CLAUDE_SKILL_DIR}/scripts/matrix-read-e2ee.py ROOM --limit 20 --json
+uv run ${CLAUDE_SKILL_DIR}/scripts/matrix-read-e2ee.py ROOM --limit 10 --request-keys
 
 # Edit / Delete / React
-uv run skills/matrix-communication/scripts/matrix-edit-e2ee.py ROOM '$eventId' "new text"
-uv run skills/matrix-communication/scripts/matrix-redact.py ROOM '$eventId' "reason"
-uv run skills/matrix-communication/scripts/matrix-react.py ROOM '$eventId' "✅"
+uv run ${CLAUDE_SKILL_DIR}/scripts/matrix-edit-e2ee.py ROOM '$eventId' "new text"
+uv run ${CLAUDE_SKILL_DIR}/scripts/matrix-redact.py ROOM '$eventId' "reason"
+uv run ${CLAUDE_SKILL_DIR}/scripts/matrix-react.py ROOM '$eventId' "✅"
 
 # Rooms
-uv run skills/matrix-communication/scripts/matrix-rooms.py
-uv run skills/matrix-communication/scripts/matrix-rooms.py --search ops
-uv run skills/matrix-communication/scripts/matrix-resolve.py "#room:server"
+uv run ${CLAUDE_SKILL_DIR}/scripts/matrix-rooms.py
+uv run ${CLAUDE_SKILL_DIR}/scripts/matrix-rooms.py --search ops
+uv run ${CLAUDE_SKILL_DIR}/scripts/matrix-resolve.py "#room:server"
 
 # E2EE management
-uv run skills/matrix-communication/scripts/matrix-e2ee-setup.py --status
-MATRIX_PASSWORD="pass" uv run skills/matrix-communication/scripts/matrix-e2ee-setup.py
-uv run skills/matrix-communication/scripts/matrix-e2ee-verify.py --timeout 180
-uv run skills/matrix-communication/scripts/matrix-fetch-keys.py ROOM --sync-time 60
-uv run skills/matrix-communication/scripts/matrix-key-backup.py --recovery-key "EsTj ..." --import-keys
+uv run ${CLAUDE_SKILL_DIR}/scripts/matrix-e2ee-setup.py --status
+MATRIX_PASSWORD="pass" uv run ${CLAUDE_SKILL_DIR}/scripts/matrix-e2ee-setup.py
+uv run ${CLAUDE_SKILL_DIR}/scripts/matrix-e2ee-verify.py --timeout 180
+uv run ${CLAUDE_SKILL_DIR}/scripts/matrix-fetch-keys.py ROOM --sync-time 60
+uv run ${CLAUDE_SKILL_DIR}/scripts/matrix-key-backup.py --recovery-key "EsTj ..." --import-keys
 
 # Health check (uses python3, not uv run)
-python3 skills/matrix-communication/scripts/matrix-doctor.py --install
+python3 ${CLAUDE_SKILL_DIR}/scripts/matrix-doctor.py --install
 ```
 
 ## Script Selection
@@ -80,7 +80,7 @@ Other: `matrix-rooms.py`, `matrix-resolve.py`, `matrix-e2ee-setup.py`, `matrix-e
 | `Could not find room` | `matrix-rooms.py` to list rooms |
 | `[Unable to decrypt]` | `matrix-key-backup.py --recovery-key "..." --import-keys` |
 | `libolm not found` | `apt install libolm-dev` / `brew install libolm` |
-| `matrix-nio not found` | `python3 skills/matrix-communication/scripts/matrix-doctor.py --install` |
+| `matrix-nio not found` | `python3 ${CLAUDE_SKILL_DIR}/scripts/matrix-doctor.py --install` |
 | `Invalid password` | Use env var: `MATRIX_PASSWORD="pass" uv run ...` |
 | `signature failed` | Dedicated device via `matrix-e2ee-setup.py` |
 


### PR DESCRIPTION
## Summary

- Replace all `skills/matrix-communication/scripts/` relative paths with `${CLAUDE_SKILL_DIR}/scripts/` in SKILL.md
- Scripts are now found regardless of the user's working directory
- `${CLAUDE_SKILL_DIR}` is the officially supported mechanism per [Claude Code docs](https://code.claude.com/docs/en/skills)

## Test plan

- [ ] Invoke skill from a project directory other than the matrix-skill repo
- [ ] `uv run ${CLAUDE_SKILL_DIR}/scripts/matrix-send-e2ee.py` resolves correctly