### PR TITLE
chore: release v1.21.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "matrix-communication",
-  "version": "1.20.1",
+  "version": "1.21.0",
   "description": "Agentic Skills for Matrix: client-side chat (matrix-communication) and Synapse homeserver administration (matrix-administration). Works with any Matrix/Synapse homeserver.",
   "author": {
     "name": "Netresearch DTT GmbH",

--- a/skills/matrix-administration/SKILL.md
+++ b/skills/matrix-administration/SKILL.md
@@ -5,7 +5,7 @@ license: "(MIT AND CC-BY-SA-4.0). See LICENSE-MIT and LICENSE-CC-BY-SA-4.0"
 compatibility: "python3 (stdlib only) + a Matrix access token belonging to a Synapse server-admin user. Optional: graphviz `dot` for SVG. Synapse 1.x with admin API enabled."
 metadata:
   author: Netresearch DTT GmbH
-  version: "1.20.1"
+  version: "1.21.0"
   repository: https://github.com/netresearch/matrix-skill
 allowed-tools: Bash(python3:*) Bash(uv:*) Bash(dot:*) Read Write
 ---

--- a/skills/matrix-communication/SKILL.md
+++ b/skills/matrix-communication/SKILL.md
@@ -5,7 +5,7 @@ license: "(MIT AND CC-BY-SA-4.0). See LICENSE-MIT and LICENSE-CC-BY-SA-4.0"
 compatibility: "Requires python3, uv. Matrix homeserver access."
 metadata:
   author: Netresearch DTT GmbH
-  version: "1.20.1"
+  version: "1.21.0"
   repository: https://github.com/netresearch/matrix-skill
 allowed-tools: Bash(python3:*) Bash(uv:*) Read Write
 ---


### PR DESCRIPTION
## Summary

Release v1.21.0 — minor bump for the new **matrix-administration** skill (Synapse Admin API operations).

| File | Old | New |
|------|-----|-----|
| `.claude-plugin/plugin.json` → `version` | 1.20.1 | **1.21.0** |
| `skills/matrix-communication/SKILL.md` → `metadata.version` | 1.20.1 | **1.21.0** |
| `skills/matrix-administration/SKILL.md` → `metadata.version` | 1.20.1 | **1.21.0** |

## What's in v1.21.0

### New: `matrix-administration` skill (#27)

Stdlib-only Python wrappers around the Synapse Admin API. Companion to `matrix-communication`. 13 scripts covering:
- Snapshot every room → `rooms.json` (paginated)
- Health rating with EN+DE phrasing (public / unencrypted / orphaned-from-spaces)
- Graphviz `.dot` + `.svg` of the room/space tree, coloured by rating
- Force-join, promote-admin, link-room-to-space
- One-shot hardening pipeline (add-to-space + restrict joins + enable encryption + restore PL on exit/SIGINT)
- Destructive user deactivation with optional GDPR `--erase`
- Inspection: where-is-user-an-admin, user-rooms, member-flow, biggest-rooms, search

Reference docs: `synapse-admin-api.md`, `room-health-checks.md`, `room-graph-pipeline.md`, `safety-guide.md`. Plus 10 evals.

### CI

- `ci: forward bump input from workflow_dispatch to reusable release workflow` (#26)

## Release assets

The reusable release workflow auto-discovers skills from `plugin.json.skills`, so v1.21.0 will publish 7 assets (matching the jira-skill convention):

- `matrix-communication-skill-v1.21.0.{tar.gz,zip}`
- `matrix-administration-skill-v1.21.0.{tar.gz,zip}` ← new
- `matrix-communication-plugin-v1.21.0.{tar.gz,zip}`
- `SHA256SUMS.txt`