### PR TITLE
fix(formatter): preserve pre-wrapped links and respect emphasis flanking

### DIFF
--- a/skills/matrix-communication/scripts/_lib/formatting.py
+++ b/skills/matrix-communication/scripts/_lib/formatting.py
@@ -14,7 +14,21 @@ def shorten_service_urls(text: str) -> str:
     - GitHub Issues/PRs: https://github.com/owner/repo/issues/123 -> [owner/repo#123](url)
     - GitHub commits: https://github.com/owner/repo/commit/abc123 -> [owner/repo@abc123](url)
     - GitLab Issues/MRs: https://gitlab.example.com/group/project/-/issues/123 -> [group/project#123](url)
+
+    URLs already inside `[text](url)` markdown links are left untouched so the
+    caller's chosen link text is preserved (and to avoid producing broken
+    nested `[text]([short](url))` shapes).
     """
+    # Protect existing markdown links from being re-wrapped.
+    protected: list[str] = []
+
+    def _protect(match: "re.Match[str]") -> str:
+        idx = len(protected)
+        protected.append(match.group(0))
+        return f"\x00MDLINK{idx}\x00"
+
+    text = re.sub(r"\[[^\]]+\]\([^)]+\)", _protect, text)
+
     # Jira URLs: https://jira.*/browse/PROJ-123 or https://*.atlassian.net/browse/PROJ-123
     text = re.sub(
         r"https?://[^/]+/browse/([A-Z][A-Z0-9]+-\d+)", r"[\1](https://\g<0>)", text
@@ -43,6 +57,9 @@ def shorten_service_urls(text: str) -> str:
         text,
     )
 
+    # Restore protected markdown links
+    text = re.sub(r"\x00MDLINK(\d+)\x00", lambda m: protected[int(m.group(1))], text)
+
     return text
 
 
@@ -56,7 +73,7 @@ def markdown_to_html(text: str) -> str:
     - ||spoiler|| text (Discord-style)
     - ```lang code blocks ```
     - > blockquotes
-    - - list items
+    - list items: `- item`, `* item`, `+ item`
     - | table | rows |
     - @user:server mentions (clickable pills)
     - #room:server room links (clickable)
@@ -107,14 +124,20 @@ def markdown_to_html(text: str) -> str:
         html,
     )
 
+    # Emphasis runs follow CommonMark left/right-flanking: the opening
+    # delimiter must NOT be followed by whitespace, and the closing one
+    # must NOT be preceded by whitespace. Without that, `* item` (a bullet)
+    # would be parsed as an italic opener and chew up the line until the
+    # next stray `*`.
+
     # Strikethrough: ~~text~~ -> <del>text</del>
-    html = re.sub(r"~~(.+?)~~", r"<del>\1</del>", html)
+    html = re.sub(r"~~(?=\S)(.+?)(?<=\S)~~", r"<del>\1</del>", html)
 
     # Bold: **text** -> <strong>text</strong>
-    html = re.sub(r"\*\*(.+?)\*\*", r"<strong>\1</strong>", html)
+    html = re.sub(r"\*\*(?=\S)(.+?)(?<=\S)\*\*", r"<strong>\1</strong>", html)
 
     # Italic: *text* -> <em>text</em>
-    html = re.sub(r"\*(.+?)\*", r"<em>\1</em>", html)
+    html = re.sub(r"\*(?=\S)([^*\n]+?)(?<=\S)\*", r"<em>\1</em>", html)
 
     # Inline code: `text` -> <code>text</code>
     html = re.sub(r"`(.+?)`", r"<code>\1</code>", html)
@@ -193,8 +216,8 @@ def markdown_to_html(text: str) -> str:
                 result.append("<blockquote>")
                 in_quote = True
             result.append(stripped[2:])
-        # Lists: - item
-        elif stripped.startswith("- "):
+        # Lists: `- item`, `* item`, `+ item` (all valid CommonMark bullets)
+        elif stripped[:2] in ("- ", "* ", "+ "):
             if in_quote:
                 result.append("</blockquote>")
                 in_quote = False

--- a/skills/matrix-communication/scripts/_lib/formatting.py
+++ b/skills/matrix-communication/scripts/_lib/formatting.py
@@ -57,8 +57,16 @@ def shorten_service_urls(text: str) -> str:
         text,
     )
 
-    # Restore protected markdown links
-    text = re.sub(r"\x00MDLINK(\d+)\x00", lambda m: protected[int(m.group(1))], text)
+    # Restore protected markdown links. Bounds-check the index so a forged
+    # placeholder in user input can't raise IndexError — unknown placeholders
+    # are left as-is.
+    def _restore(match: "re.Match[str]") -> str:
+        idx = int(match.group(1))
+        if 0 <= idx < len(protected):
+            return protected[idx]
+        return match.group(0)
+
+    text = re.sub(r"\x00MDLINK(\d+)\x00", _restore, text)
 
     return text
 

--- a/skills/matrix-communication/scripts/_lib/test_formatting.py
+++ b/skills/matrix-communication/scripts/_lib/test_formatting.py
@@ -1,7 +1,12 @@
 """Tests for `_lib.formatting` markdown→HTML conversion.
 
-Run with: `python3 -m unittest skills.matrix-communication.scripts._lib.test_formatting`
-or invoke this file directly: `python3 test_formatting.py`.
+The skill directory contains a hyphen (`matrix-communication`) so it is
+not importable as a Python package; run the file directly or use unittest
+discovery:
+
+    python3 skills/matrix-communication/scripts/_lib/test_formatting.py
+    python3 -m unittest discover \\
+        -s skills/matrix-communication/scripts/_lib -p 'test_formatting.py'
 
 Stdlib only.
 """
@@ -36,9 +41,7 @@ class ShortenServiceUrlsTests(unittest.TestCase):
         confused the link parser and leaked literal `)` into the rendered
         message.
         """
-        src = (
-            "[mytext](https://gitlab.example.com/grp/proj/-/merge_requests/7) — note"
-        )
+        src = "[mytext](https://gitlab.example.com/grp/proj/-/merge_requests/7) — note"
         out = shorten_service_urls(src)
         self.assertEqual(out, src)
 
@@ -66,6 +69,14 @@ class ShortenServiceUrlsTests(unittest.TestCase):
         self.assertIn(
             "[grp/proj#12](https://gitlab.example.com/grp/proj/-/issues/12)", out
         )
+
+    def test_forged_placeholder_does_not_raise(self):
+        """A user-supplied `\\x00MDLINK<n>\\x00` sequence must not crash the
+        restore step with IndexError. Unknown placeholders are left as-is."""
+        # No real markdown link in the input, but a forged placeholder is.
+        src = "literal placeholder \x00MDLINK99\x00 should pass through"
+        out = shorten_service_urls(src)
+        self.assertIn("\x00MDLINK99\x00", out)
 
 
 class MarkdownToHtmlListTests(unittest.TestCase):
@@ -152,9 +163,7 @@ class MarkdownToHtmlLinkTests(unittest.TestCase):
     def test_pre_wrapped_jira_link_renders_clean_anchor(self):
         src = "[NRS-1](https://jira.example.com/browse/NRS-1)"
         html = markdown_to_html(src)
-        self.assertIn(
-            '<a href="https://jira.example.com/browse/NRS-1">NRS-1</a>', html
-        )
+        self.assertIn('<a href="https://jira.example.com/browse/NRS-1">NRS-1</a>', html)
         self.assertNotIn("</a>)", html)
 
     def test_bullet_list_with_pre_wrapped_links(self):
@@ -176,9 +185,7 @@ class MarkdownToHtmlLinkTests(unittest.TestCase):
             "proj#7</a>",
             html,
         )
-        self.assertIn(
-            '<a href="https://jira.example.com/browse/NRS-1">NRS-1</a>', html
-        )
+        self.assertIn('<a href="https://jira.example.com/browse/NRS-1">NRS-1</a>', html)
         # No nested `[…](…)` artefacts (the symptom of broken re-wrapping)
         self.assertNotIn("[", html)
         self.assertNotIn("](", html)

--- a/skills/matrix-communication/scripts/_lib/test_formatting.py
+++ b/skills/matrix-communication/scripts/_lib/test_formatting.py
@@ -1,0 +1,190 @@
+"""Tests for `_lib.formatting` markdown→HTML conversion.
+
+Run with: `python3 -m unittest skills.matrix-communication.scripts._lib.test_formatting`
+or invoke this file directly: `python3 test_formatting.py`.
+
+Stdlib only.
+"""
+
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(__file__))
+
+from formatting import markdown_to_html, shorten_service_urls  # noqa: E402
+
+
+class ShortenServiceUrlsTests(unittest.TestCase):
+    def test_jira_bare_url_is_shortened(self):
+        out = shorten_service_urls("see https://jira.example.com/browse/PROJ-42")
+        self.assertIn("[PROJ-42](https://jira.example.com/browse/PROJ-42)", out)
+
+    def test_gitlab_bare_url_is_shortened(self):
+        out = shorten_service_urls(
+            "see https://gitlab.example.com/grp/proj/-/merge_requests/7"
+        )
+        self.assertIn(
+            "[grp/proj#7](https://gitlab.example.com/grp/proj/-/merge_requests/7)",
+            out,
+        )
+
+    def test_existing_gitlab_markdown_link_is_preserved(self):
+        """Regression: pre-wrapped markdown links must NOT be re-wrapped.
+
+        Before the fix this produced `[mytext]([grp/proj#7](url))` which
+        confused the link parser and leaked literal `)` into the rendered
+        message.
+        """
+        src = (
+            "[mytext](https://gitlab.example.com/grp/proj/-/merge_requests/7) — note"
+        )
+        out = shorten_service_urls(src)
+        self.assertEqual(out, src)
+
+    def test_existing_jira_markdown_link_is_preserved(self):
+        src = "[NRS-1](https://jira.example.com/browse/NRS-1) — note"
+        out = shorten_service_urls(src)
+        self.assertEqual(out, src)
+
+    def test_existing_github_markdown_link_is_preserved(self):
+        src = "[my pr](https://github.com/owner/repo/pull/9) — note"
+        out = shorten_service_urls(src)
+        self.assertEqual(out, src)
+
+    def test_mixed_protected_and_bare_urls(self):
+        src = (
+            "see [my mr](https://gitlab.example.com/grp/proj/-/merge_requests/7) "
+            "and https://gitlab.example.com/grp/proj/-/issues/12"
+        )
+        out = shorten_service_urls(src)
+        # First link untouched
+        self.assertIn(
+            "[my mr](https://gitlab.example.com/grp/proj/-/merge_requests/7)", out
+        )
+        # Second link auto-shortened
+        self.assertIn(
+            "[grp/proj#12](https://gitlab.example.com/grp/proj/-/issues/12)", out
+        )
+
+
+class MarkdownToHtmlListTests(unittest.TestCase):
+    def test_dash_bullets_render_as_ul(self):
+        html = markdown_to_html("- one\n- two")
+        self.assertIn("<ul>", html)
+        self.assertIn("<li>one</li>", html)
+        self.assertIn("<li>two</li>", html)
+
+    def test_asterisk_bullets_render_as_ul(self):
+        """Regression: `* ` bullets must render as a list, not as italic."""
+        html = markdown_to_html("* one\n* two")
+        self.assertIn("<ul>", html)
+        self.assertIn("<li>one</li>", html)
+        self.assertIn("<li>two</li>", html)
+        self.assertNotIn("<em>", html)
+
+    def test_plus_bullets_render_as_ul(self):
+        html = markdown_to_html("+ one\n+ two")
+        self.assertIn("<ul>", html)
+        self.assertIn("<li>one</li>", html)
+        self.assertIn("<li>two</li>", html)
+
+    def test_asterisk_bullet_with_inline_italic(self):
+        """A bullet line may still contain an italic span elsewhere."""
+        html = markdown_to_html("* item *emph* tail")
+        self.assertIn("<li>item <em>emph</em> tail</li>", html)
+
+    def test_asterisk_inside_word_still_italicises(self):
+        """Mid-line `*pairs*` still emit <em>."""
+        html = markdown_to_html("hello *world*")
+        self.assertIn("<em>world</em>", html)
+
+
+class EmphasisFlankingTests(unittest.TestCase):
+    """CommonMark left/right-flanking rules for `*…*`, `**…**`, `~~…~~`.
+
+    Opening delimiter must NOT be followed by whitespace; closing delimiter
+    must NOT be preceded by whitespace. Without these guards the italic
+    regex used to swallow bullet `*` markers and produce broken output.
+    """
+
+    def test_italic_open_followed_by_space_does_not_match(self):
+        # `*` immediately followed by space is not a valid italic opener.
+        html = markdown_to_html("* one and *two*")
+        self.assertNotIn("<em> one and </em>", html)
+        self.assertIn("<em>two</em>", html)
+
+    def test_italic_close_preceded_by_space_does_not_match(self):
+        # `*` immediately preceded by space is not a valid italic closer.
+        html = markdown_to_html("a *foo *bar")
+        self.assertNotIn("<em>foo </em>", html)
+
+    def test_bold_open_followed_by_space_does_not_match(self):
+        html = markdown_to_html("** not bold ** but **bold**")
+        self.assertNotIn("<strong> not bold </strong>", html)
+        self.assertIn("<strong>bold</strong>", html)
+
+    def test_strikethrough_open_followed_by_space_does_not_match(self):
+        html = markdown_to_html("~~ not strike ~~ but ~~strike~~")
+        self.assertNotIn("<del> not strike </del>", html)
+        self.assertIn("<del>strike</del>", html)
+
+    def test_italic_single_char(self):
+        # `*x*` is a valid italic: opener followed by non-ws, closer
+        # preceded by non-ws.
+        html = markdown_to_html("*x*")
+        self.assertIn("<em>x</em>", html)
+
+
+class MarkdownToHtmlLinkTests(unittest.TestCase):
+    def test_pre_wrapped_gitlab_link_renders_clean_anchor(self):
+        """Regression: no stray `)` after the anchor."""
+        src = "[my mr](https://gitlab.example.com/grp/proj/-/merge_requests/7)"
+        html = markdown_to_html(src)
+        self.assertIn(
+            '<a href="https://gitlab.example.com/grp/proj/-/merge_requests/7">'
+            "my mr</a>",
+            html,
+        )
+        # Critical: no leaked closing paren after the anchor
+        self.assertNotIn("</a>)", html)
+
+    def test_pre_wrapped_jira_link_renders_clean_anchor(self):
+        src = "[NRS-1](https://jira.example.com/browse/NRS-1)"
+        html = markdown_to_html(src)
+        self.assertIn(
+            '<a href="https://jira.example.com/browse/NRS-1">NRS-1</a>', html
+        )
+        self.assertNotIn("</a>)", html)
+
+    def test_bullet_list_with_pre_wrapped_links(self):
+        """End-to-end regression: a bullet list of pre-wrapped GitLab + Jira
+        links must produce a clean `<ul><li><a>…</a></li>…</ul>` tree, with
+        the pre-wrapped link text preserved (not replaced by the auto-shortener).
+        """
+        src = (
+            "- [proj#7](https://gitlab.example.com/grp/proj/-/merge_requests/7) "
+            "— note ([NRS-1](https://jira.example.com/browse/NRS-1))\n"
+            "- [proj#8](https://gitlab.example.com/grp/proj/-/merge_requests/8)"
+        )
+        html = markdown_to_html(src)
+        self.assertIn("<ul>", html)
+        # Caller-provided link text preserved (would have been clobbered to
+        # `grp/proj#7` by the broken auto-shortener)
+        self.assertIn(
+            '<a href="https://gitlab.example.com/grp/proj/-/merge_requests/7">'
+            "proj#7</a>",
+            html,
+        )
+        self.assertIn(
+            '<a href="https://jira.example.com/browse/NRS-1">NRS-1</a>', html
+        )
+        # No nested `[…](…)` artefacts (the symptom of broken re-wrapping)
+        self.assertNotIn("[", html)
+        self.assertNotIn("](", html)
+        # Sanity: no leftover bullet asterisks (would mean inline ate the bullet)
+        self.assertNotIn("<li>*", html)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Fixes two formatter bugs in `_lib/formatting.py` that produced visibly broken Element output.

### Bug 1 — `shorten_service_urls()` clobbers pre-wrapped markdown links

The auto-shortener ran its URL substitutions against the whole input, including inside existing `[text](url)` markdown links. A caller-supplied `[my mr](https://gitlab.example/grp/proj/-/merge_requests/7)` got re-wrapped to `[my mr]([grp/proj#7](https://gitlab.example/grp/proj/-/merge_requests/7))`. The downstream link regex `\[([^\]]+)\]\(([^)]+)\)` then matched the **outer** brackets and the URL up to the **first** `)` — leaving a stray `)` in the rendered HTML and stuffing markdown syntax into the `href` attribute.

**Fix**: stash existing `[text](url)` matches as placeholders before applying the URL substitutions, restore them at the end. Caller-supplied link text is preserved untouched.

### Bug 2 — emphasis regexes ignore CommonMark left/right-flanking

The naïve `\*(.+?)\*`, `\*\*(.+?)\*\*`, `~~(.+?)~~` patterns matched **any** delimiter pair, including ones that violate the CommonMark flanking rules:

- An **opening** delimiter must NOT be followed by whitespace
- A **closing** delimiter must NOT be preceded by whitespace

That's exactly what distinguishes `* bullet` (followed by space → not an italic opener) from `*foo*` (followed by non-space → italic opener). Without the guard, the italic regex happily treated a bullet `*` as an italic opener and gobbled the line up to the next stray `*`, italicising the wrong span and leaving a stray `*` for users to see.

**Fix**: anchor each emphasis regex with `(?=\S)` after the opener and `(?<=\S)` before the closer. Italic additionally forbids `*` in its content (`[^*\n]+?`) so it can't span past a closing `**` of bold.

Also extends the line-based list detector to recognise `* item` and `+ item` (in addition to `- item`) — all three are valid CommonMark bullet markers and now stay intact through inline processing.

## Tests

Adds `_lib/test_formatting.py` with **19 unit tests** covering:

- Both regressions (link clobber, bullet-eaten-by-italic)
- The flanking semantics for italic / bold / strikethrough (open-after-space and close-before-space cases)
- Happy paths: bare URL auto-shortening, `*`/`+`/`-` bullets, bold/strike still working

Stdlib `unittest` only — runs with:

\`\`\`bash
python3 skills/matrix-communication/scripts/_lib/test_formatting.py
\`\`\`

All 19 pass locally:

\`\`\`
Ran 19 tests in 0.002s
OK
\`\`\`

## Test plan

- [x] Unit tests pass (`python3 .../test_formatting.py`)
- [x] `ruff check` clean
- [x] Manually verified the fix renders a previously-broken message correctly:
  - Bullets become `<ul><li>…</li></ul>` (no literal `*`)
  - Pre-wrapped GitLab MR links keep caller's chosen anchor text (e.g. `server-playbooks!316`, not auto-shortened to `netresearch-administration/server-playbooks#316`)
  - Pre-wrapped Jira links render as clean `<a href="…">NRS-XXXX</a>` with no trailing `)`
  - `*foo*`, `**foo**`, `~~foo~~` still work mid-line
  - `* foo *` (bullet-like, both sides spaced) is correctly NOT italic
- [ ] CI lint workflow passes