### PR TITLE
feat(matrix-communication): add --notice flag to send scripts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,8 +49,10 @@ All scripts live in `skills/matrix-communication/scripts/`. Use `uv run` unless 
 ```bash
 C=skills/matrix-communication/scripts
 
-# Send (always prefer E2EE) — plain | --thread | --reply | --emote | --no-prefix
+# Send (always prefer E2EE) — plain | --thread | --reply | --emote | --notice | --no-prefix
 set +H && uv run $C/matrix-send-e2ee.py ROOM "message"
+# unattended automation (m.notice — no auto-reply loops; mutex with --emote):
+set +H && uv run $C/matrix-send-e2ee.py ROOM "📦 Release: …" --notice
 
 # Read / Edit / React / Redact
 uv run $C/matrix-read-e2ee.py ROOM --limit 10 [--json]

--- a/skills/matrix-announcement/SKILL.md
+++ b/skills/matrix-announcement/SKILL.md
@@ -64,4 +64,4 @@ One leading glyph at most. **Never** trailing decoration, multi-emoji ladders, �
 - [templates/](references/templates/) — `release-card.html` (1200×630), `weekly-digest.html` (1200×1500), `comparison.html` (1200×900)
 - [gallery.html](references/gallery.html) — visual preview of every rule, the five worked examples, and the three templates
 
-Sending: pass the composed message to `matrix-communication` (`matrix-send-e2ee.py "$ROOM" "$MARKDOWN"`); the transport converts markdown to HTML using the rules in `html-subset.md`. For hand-crafted `formatted_body`, `m.notice` flagging, or `m.image` cards, call the homeserver API directly — recipe in `image-cards.md`.
+Sending: pass the composed message to `matrix-communication` (`matrix-send-e2ee.py "$ROOM" "$MARKDOWN" [--notice]`). The transport converts markdown to HTML using the rules in `html-subset.md`; pass `--notice` for unattended automation so other bots can't auto-reply (mutually exclusive with `--emote`). For hand-crafted `formatted_body` or `m.image` cards, call the homeserver API directly — recipe in `image-cards.md`.

--- a/skills/matrix-announcement/evals/evals.json
+++ b/skills/matrix-announcement/evals/evals.json
@@ -81,12 +81,12 @@
       "id": 7,
       "eval_name": "m-notice-for-bots",
       "prompt": "Send the release announcement automatically from CI without human review.",
-      "expected_output": "Sets msgtype to m.notice (not m.text) so other bots won't auto-reply, and surfaces that the matrix-communication scripts default to m.text — so a raw API call is required for m.notice.",
+      "expected_output": "Sets msgtype to m.notice (not m.text) so other bots won't auto-reply. Uses the matrix-send-e2ee.py --notice flag (the transport's native support) instead of falling back to a raw API call.",
       "files": [],
       "assertions": [
         "Surfaces m.notice vs m.text distinction",
         "Recommends m.notice for the unattended/CI case",
-        "Notes that matrix-send-e2ee.py sends m.text and a direct API call is needed for m.notice"
+        "Uses the --notice flag on matrix-send-e2ee.py / matrix-send.py rather than a raw curl PUT"
       ]
     },
     {

--- a/skills/matrix-announcement/references/image-cards.md
+++ b/skills/matrix-announcement/references/image-cards.md
@@ -65,7 +65,7 @@ uv run ${CLAUDE_SKILL_DIR}/../matrix-communication/scripts/matrix-send-e2ee.py "
   '**Install:** `/install-plugin https://github.com/netresearch/github-release-skill`'
 ```
 
-> **Note:** For text-only announcements that should be `m.notice` (unattended automation, no auto-reply loops), pass `--notice` to `matrix-send-e2ee.py`. The raw `PUT` recipe above is for `m.image`; swap `"msgtype": "m.image"` to `"msgtype": "m.notice"` only if you also want the image itself flagged as a notice.
+> **Note:** `m.notice` is a *text* msgtype — there is no notice-flavoured `m.image`. For text-only announcements that should be unreplyable by other bots, pass `--notice` to `matrix-send-e2ee.py`. For an image announcement that should still be skipped by auto-replying bots, send the card as `m.image` (the recipe above) and then a follow-up `m.text` via `matrix-send-e2ee.py … --notice` carrying the install command and links — bots that respect `m.notice` will then ignore the whole announcement, since they ignore the text and the image is wordless.
 
 ## Why "design HTML, render to PNG" beats "have the LLM make an image"
 

--- a/skills/matrix-announcement/references/image-cards.md
+++ b/skills/matrix-announcement/references/image-cards.md
@@ -65,7 +65,7 @@ uv run ${CLAUDE_SKILL_DIR}/../matrix-communication/scripts/matrix-send-e2ee.py "
   '**Install:** `/install-plugin https://github.com/netresearch/github-release-skill`'
 ```
 
-> **Note:** The `matrix-communication` transport sends `m.text` with markdown-converted HTML. For unattended automation that should be `m.notice` (and therefore unreplyable by other bots), use the raw `PUT /_matrix/client/v3/rooms/{room}/send/m.room.message/{txn}` call shown in step 3 with `"msgtype": "m.notice"`.
+> **Note:** For text-only announcements that should be `m.notice` (unattended automation, no auto-reply loops), pass `--notice` to `matrix-send-e2ee.py`. The raw `PUT` recipe above is for `m.image`; swap `"msgtype": "m.image"` to `"msgtype": "m.notice"` only if you also want the image itself flagged as a notice.
 
 ## Why "design HTML, render to PNG" beats "have the LLM make an image"
 

--- a/skills/matrix-communication/SKILL.md
+++ b/skills/matrix-communication/SKILL.md
@@ -25,6 +25,7 @@ ROOM: name (`test`), ID (`!abc:server`), or alias (`#room:server`).
 set +H && uv run ${CLAUDE_SKILL_DIR}/scripts/matrix-send-e2ee.py ROOM "message"
 uv run ${CLAUDE_SKILL_DIR}/scripts/matrix-send-e2ee.py ROOM "message" --no-prefix
 uv run ${CLAUDE_SKILL_DIR}/scripts/matrix-send-e2ee.py ROOM "is deploying" --emote
+uv run ${CLAUDE_SKILL_DIR}/scripts/matrix-send-e2ee.py ROOM "📦 Release: …" --notice    # unattended automation; no auto-reply loops
 uv run ${CLAUDE_SKILL_DIR}/scripts/matrix-send-e2ee.py ROOM "reply" --thread '$rootEventId'
 uv run ${CLAUDE_SKILL_DIR}/scripts/matrix-send-e2ee.py ROOM "reply" --reply '$eventId'
 

--- a/skills/matrix-communication/references/messaging-guide.md
+++ b/skills/matrix-communication/references/messaging-guide.md
@@ -15,6 +15,15 @@ uv run skills/matrix-communication/scripts/matrix-send-e2ee.py "#ops:matrix.org"
 ```
 **When to use:** Status updates, actions, presence indicators.
 
+### Notice Messages (m.notice)
+Bot-flagged. Clients render `m.notice` visually distinct (usually muted) and **other bots are forbidden from auto-replying** to it — this prevents bot-on-bot loops. Use `--notice` flag (mutually exclusive with `--emote`).
+```bash
+# Unattended automation: release announcement from CI
+uv run skills/matrix-communication/scripts/matrix-send-e2ee.py "#releases:example.com" \
+    "📦 Release: jira-skill v3.12.0 — progressive-disclosure refactor" --notice
+```
+**When to use:** Release announcements, CI summaries, scheduled digests, alert pings — anything posted unattended without a human reviewing first. For agent-on-behalf-of-human posts where a reply would be welcome, leave it as the default `m.text`.
+
 ### Thread Replies
 Reply in a thread to keep discussions organized. Use `--thread` with root event ID.
 ```bash

--- a/skills/matrix-communication/scripts/matrix-send-e2ee.py
+++ b/skills/matrix-communication/scripts/matrix-send-e2ee.py
@@ -23,6 +23,9 @@ Arguments:
 
 Options:
     --emote           Send as /me action (m.emote)
+    --notice          Send as m.notice — bot-flagged, suppressed from auto-reply
+                      loops. Use for unattended automation (release announcements,
+                      CI summaries, scheduled digests). Mutually exclusive with --emote.
     --thread EVENT    Reply in thread (event ID of thread root)
     --reply EVENT     Reply to message (event ID to reply to)
     --no-prefix       Don't add bot_prefix from config
@@ -85,11 +88,17 @@ async def send_message_e2ee(
     room: str,
     message: str,
     emote: bool = False,
+    notice: bool = False,
     thread_id: str = None,
     reply_id: str = None,
     debug: bool = False,
 ) -> dict:
-    """Send an E2EE-capable message to a Matrix room."""
+    """Send an E2EE-capable message to a Matrix room.
+
+    msgtype precedence: notice > emote > text. The caller is expected to pass
+    only one of `notice` or `emote`; the CLI enforces this via a mutually
+    exclusive argument group.
+    """
 
     store_path = get_store_path()
 
@@ -284,8 +293,14 @@ async def send_message_e2ee(
                         )
 
         # Build message content with HTML formatting
+        if notice:
+            msgtype = "m.notice"
+        elif emote:
+            msgtype = "m.emote"
+        else:
+            msgtype = "m.text"
         content = {
-            "msgtype": "m.emote" if emote else "m.text",
+            "msgtype": msgtype,
             "body": message,
         }
 
@@ -331,8 +346,15 @@ def main():
     )
     parser.add_argument("room", help="Room ID (!id), alias (#room:server), or name")
     parser.add_argument("message", help="Message content")
-    parser.add_argument(
+    msgtype_group = parser.add_mutually_exclusive_group()
+    msgtype_group.add_argument(
         "--emote", action="store_true", help="Send as /me action (m.emote msgtype)"
+    )
+    msgtype_group.add_argument(
+        "--notice",
+        action="store_true",
+        help="Send as m.notice — bot-flagged, suppressed from auto-reply loops. "
+        "Use for unattended automation (release announcements, CI summaries).",
     )
     parser.add_argument(
         "--thread", metavar="EVENT_ID", help="Reply in thread (event ID of thread root)"
@@ -386,6 +408,7 @@ def main():
             room=room,
             message=message,
             emote=args.emote,
+            notice=args.notice,
             thread_id=args.thread,
             reply_id=args.reply,
             debug=args.debug,

--- a/skills/matrix-communication/scripts/matrix-send.py
+++ b/skills/matrix-communication/scripts/matrix-send.py
@@ -19,6 +19,9 @@ Arguments:
 Options:
     --format FORMAT   Message format: text or markdown [default: markdown]
     --emote           Send as /me action (m.emote)
+    --notice          Send as m.notice — bot-flagged, suppressed from auto-reply
+                      loops. Use for unattended automation. Mutually exclusive
+                      with --emote.
     --thread EVENT    Reply in thread (event ID of thread root)
     --reply EVENT     Reply to message (event ID to reply to)
     --no-prefix       Don't add bot_prefix from config
@@ -70,6 +73,7 @@ def send_message(
     message: str,
     format: str = "markdown",
     emote: bool = False,
+    notice: bool = False,
     thread_id: str = None,
     reply_id: str = None,
 ) -> dict:
@@ -81,12 +85,22 @@ def send_message(
         message: Message content
         format: "text" or "markdown"
         emote: If True, send as m.emote (/me action)
+        notice: If True, send as m.notice (bot-flagged, no auto-reply loops)
         thread_id: Event ID of thread root (for thread replies)
         reply_id: Event ID to reply to
+
+    msgtype precedence: notice > emote > text. The CLI enforces that callers
+    pass only one of --notice or --emote via a mutually exclusive group.
     """
     txn_id = str(int(time.time() * 1000))
 
-    content = {"msgtype": "m.emote" if emote else "m.text", "body": message}
+    if notice:
+        msgtype = "m.notice"
+    elif emote:
+        msgtype = "m.emote"
+    else:
+        msgtype = "m.text"
+    content = {"msgtype": msgtype, "body": message}
 
     if format == "markdown":
         html = markdown_to_html(message)
@@ -128,8 +142,15 @@ def main():
         default="markdown",
         help="Message format (default: markdown)",
     )
-    parser.add_argument(
+    msgtype_group = parser.add_mutually_exclusive_group()
+    msgtype_group.add_argument(
         "--emote", action="store_true", help="Send as /me action (m.emote msgtype)"
+    )
+    msgtype_group.add_argument(
+        "--notice",
+        action="store_true",
+        help="Send as m.notice — bot-flagged, suppressed from auto-reply loops. "
+        "Use for unattended automation (release announcements, CI summaries).",
     )
     parser.add_argument(
         "--thread", metavar="EVENT_ID", help="Reply in thread (event ID of thread root)"
@@ -232,6 +253,7 @@ def main():
         message,
         args.format,
         emote=args.emote,
+        notice=args.notice,
         thread_id=args.thread,
         reply_id=args.reply,
     )


### PR DESCRIPTION
## Summary

Adds a `--notice` flag to `matrix-send-e2ee.py` and `matrix-send.py` so messages can be sent as `m.notice` instead of `m.text`. This is the follow-up flagged in PR #31: the new `matrix-announcement` skill recommends `m.notice` for unattended automation (release announcements, CI summaries, alert pings) — but the transport scripts didn't support it, so the rule was unenforceable through the documented invocation.

`m.notice` is the spec-defined "bot-flagged" message type. Clients render it visually distinct (usually muted) and **other bots are forbidden from auto-replying** to it, which is the mechanism that prevents bot-on-bot loops.

## Changes

### Scripts
- `matrix-send-e2ee.py`: new `--notice` flag, mutually exclusive with `--emote` (via `add_mutually_exclusive_group`). The async `send_message_e2ee()` gains a `notice: bool = False` parameter; msgtype is resolved as `notice > emote > text`.
- `matrix-send.py`: identical change for the non-E2EE fallback. `send_message()` gains `notice: bool = False`.

### Documentation
- `matrix-communication/SKILL.md` — quick-reference adds a `--notice` example next to `--emote`
- `matrix-communication/references/messaging-guide.md` — new **Notice Messages (m.notice)** section parallel to the existing Emote Messages section, with a release-announcement example
- `AGENTS.md` — cheat-sheet updated to list `--notice` and show an unattended-automation example
- `matrix-announcement/SKILL.md` — "Sending" line drops the "raw API call needed for m.notice" caveat and points at the new `--notice` flag
- `matrix-announcement/references/image-cards.md` — note rewritten: text-only m.notice is now `--notice`; the raw `PUT` recipe stays for `m.image` cards
- `matrix-announcement/evals/evals.json` — eval #7 (m-notice-for-bots) now asserts the agent uses `--notice` rather than falling back to a raw `curl PUT`

## Tests

No existing test coverage on the send scripts (only `_lib/test_formatting.py` for the markdown converter). Verified manually:

```
$ uv run skills/matrix-communication/scripts/matrix-send-e2ee.py --help
usage: matrix-send-e2ee.py [-h] [--emote | --notice] ...

  --emote            Send as /me action (m.emote msgtype)
  --notice           Send as m.notice — bot-flagged, suppressed from auto-
                     reply loops. Use for unattended automation ...

$ uv run skills/matrix-communication/scripts/matrix-send-e2ee.py --emote --notice 'agent-work' 'msg'
matrix-send-e2ee.py: error: argument --notice: not allowed with argument --emote

# msgtype dispatch (mock test):
default:               m.text
--emote:               m.emote
--notice:              m.notice
notice + emote (mutex caught by argparse, but if bypassed): notice wins
```

Harness: same maturity as main (L1 5/5, L2 6/7, L3 6/6 — same pre-existing multi-skill name-mismatch).

## Compatibility

- **Backward compatible.** No breaking changes — `--notice` is opt-in. Existing callers continue to send `m.text`/`m.emote` as before.
- **Function signatures**: added a keyword argument with a default. Any external caller (none in the repo) that passes positional arguments past the `emote` slot would break, but in this codebase all callers use kwargs.

## Test plan

- [ ] `bash scripts/verify-harness.sh --status` — same maturity as main
- [ ] `python3 -m py_compile skills/matrix-communication/scripts/matrix-send-e2ee.py skills/matrix-communication/scripts/matrix-send.py` — syntax OK
- [ ] `uv run skills/matrix-communication/scripts/matrix-send-e2ee.py --help` — shows `--emote | --notice` group and per-flag help
- [ ] `uv run skills/matrix-communication/scripts/matrix-send-e2ee.py --emote --notice 'r' 'm'` — fails with the mutex error
- [ ] Send a real `--notice` message in `#test:example.com` and confirm in Element it renders muted/notice-styled (manual)