### PR TITLE
chore: release v1.22.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "matrix-communication",
-  "version": "1.21.1",
+  "version": "1.22.0",
   "description": "Agentic Skills for Matrix: client-side chat (matrix-communication), Synapse homeserver administration (matrix-administration), and structured announcement composition (matrix-announcement). Works with any Matrix/Synapse homeserver.",
   "author": {
     "name": "Netresearch DTT GmbH",

--- a/skills/matrix-administration/SKILL.md
+++ b/skills/matrix-administration/SKILL.md
@@ -5,7 +5,7 @@ license: "(MIT AND CC-BY-SA-4.0). See LICENSE-MIT and LICENSE-CC-BY-SA-4.0"
 compatibility: "python3 (stdlib only) + a Matrix access token belonging to a Synapse server-admin user. Optional: graphviz `dot` for SVG. Synapse 1.x with admin API enabled."
 metadata:
   author: Netresearch DTT GmbH
-  version: "1.21.1"
+  version: "1.22.0"
   repository: https://github.com/netresearch/matrix-skill
 allowed-tools: Bash(python3:*) Bash(uv:*) Bash(dot:*) Read Write
 ---

--- a/skills/matrix-announcement/README.md
+++ b/skills/matrix-announcement/README.md
@@ -40,7 +40,7 @@ Grab the [latest release](https://github.com/netresearch/matrix-skill/releases/l
 The skill triggers on any agent-authored Matrix post longer than a single line. Examples:
 
 ```
-"Announce the v1.21.1 release in #releases:example.com"
+"Announce the vX.Y.Z release in #releases:example.com"
 "Post the weekly skill digest"
 "Heads-up the team that matrix-skill v2 drops Python 3.8"
 "Render a comparison card for the new auth flow and post it"

--- a/skills/matrix-announcement/SKILL.md
+++ b/skills/matrix-announcement/SKILL.md
@@ -5,7 +5,7 @@ license: "(MIT AND CC-BY-SA-4.0). See LICENSE-MIT and LICENSE-CC-BY-SA-4.0"
 compatibility: "Pairs with matrix-communication for sending. Optional: headless Chromium for rendering HTML cards to PNG."
 metadata:
   author: Netresearch DTT GmbH
-  version: "1.21.1"
+  version: "1.22.0"
   repository: https://github.com/netresearch/matrix-skill
 allowed-tools: Bash(chromium:*) Bash(curl:*) Bash(jq:*) Read Write
 ---

--- a/skills/matrix-announcement/references/gallery.html
+++ b/skills/matrix-announcement/references/gallery.html
@@ -867,7 +867,7 @@ jira-attachment.py add PROJ-123 /tmp/image.png</code></pre>
       </div>
     </section>
 
-    <p class="footer-note">Skill: matrix-announcement · v1.21.1 · paired with SKILL.md</p>
+    <p class="footer-note">Skill: matrix-announcement · v1.22.0 · paired with SKILL.md</p>
   </main>
 </div>
 

--- a/skills/matrix-communication/SKILL.md
+++ b/skills/matrix-communication/SKILL.md
@@ -5,7 +5,7 @@ license: "(MIT AND CC-BY-SA-4.0). See LICENSE-MIT and LICENSE-CC-BY-SA-4.0"
 compatibility: "Requires python3, uv. Matrix homeserver access."
 metadata:
   author: Netresearch DTT GmbH
-  version: "1.21.1"
+  version: "1.22.0"
   repository: https://github.com/netresearch/matrix-skill
 allowed-tools: Bash(python3:*) Bash(uv:*) Read Write
 ---


### PR DESCRIPTION
## v1.22.0 — minor

Bumps `plugin.json` and the three skill `SKILL.md` `metadata.version` fields from `1.21.1` → `1.22.0`. Also updates the gallery footer.

### Changes since v1.21.1

```
$ git log --oneline --no-merges v1.21.1..main
ad44452 fix: correct m.notice/m.image guidance per Copilot review on PR #32
0d11921 feat(matrix-communication): add --notice flag to send scripts
968e609 docs: replace company-internal URLs with example.com placeholders
2eb8e17 fix: address Copilot review comments on PR #31
504a587 fix: address Gemini review comments on PR #31
0933120 feat: add matrix-announcement skill for structured room posts
```

Two feature themes:

- **`matrix-announcement` skill (PR #31).** New third skill alongside `matrix-communication` (transport) and `matrix-administration` (Synapse ops). Content guidance for composing scannable, structured Matrix announcements: HTML subset, type-tag system (`Release` / `Patch` / `Heads-up` / `Digest` / `Postmortem` / `RFC` / `New skill`), glyph rules (no rockets, no party emoji), `m.text` vs `m.notice` choice, and when to render an HTML card to PNG. Ships seven references, three rendered HTML card templates (1200×630 / 1200×1500 / 1200×900), 12 evals, and a visual gallery. No scripts.
- **`--notice` flag on the send scripts (PR #32).** `matrix-send-e2ee.py` and `matrix-send.py` now accept `--notice` (mutually exclusive with `--emote`) so unattended automation can send `m.notice` and not be auto-replied to by other bots — closing the gap the announcement skill recommended but the transport didn't support.

### Files modified

- `.claude-plugin/plugin.json` — `version: 1.21.1` → `1.22.0`
- `skills/matrix-communication/SKILL.md` — `metadata.version: "1.21.1"` → `"1.22.0"`
- `skills/matrix-administration/SKILL.md` — same
- `skills/matrix-announcement/SKILL.md` — same
- `skills/matrix-announcement/references/gallery.html` — footer `v1.21.1` → `v1.22.0`

### Pre-existing infra gaps (not introduced here)

`validate-pre-release.sh` flags three pre-existing items that v1.21.1 was also released against:

- No `CHANGELOG.md` in the repo
- `release.yml` lacks `id-token:write` / `attestations:write` permissions (SLSA provenance / cosign signing)
- 3 lightweight tags exist for old releases: `v1.15.2`, `v1.17.1`, `v1.20.1`

These are worth a separate hardening PR; not blocking this release.

## Test plan

- [ ] All 4 version strings in the diff agree at `1.22.0`
- [ ] CI green on the release branch
- [ ] After merge: `git tag -s v1.22.0 -m "v1.22.0"` and `git push origin v1.22.0`
- [ ] Release workflow on tag push publishes the GitHub Release
- [ ] Auto-generated release notes get rewritten into a narrative