### PR TITLE
docs: add CHANGELOG.md (release hardening)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,55 @@
+# Changelog
+
+All notable changes to this project are documented here. The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+For the canonical narrative version of each release (rewritten after CI publishes the auto-generated notes), see the matching entry on the [releases page](https://github.com/netresearch/matrix-skill/releases).
+
+## [Unreleased]
+
+### Added
+
+### Changed
+
+### Fixed
+
+### Removed
+
+## [1.22.0] - 2026-04-29
+
+### Added
+
+- **`matrix-announcement` skill** — third skill in the plugin, alongside `matrix-communication` (transport) and `matrix-administration` (Synapse ops). Content guidance for composing scannable, structured Matrix room announcements: HTML subset clients render, type-tag system (`Release` / `Patch` / `Heads-up` / `Digest` / `Postmortem` / `RFC` / `New skill`), glyph rules, `m.text` vs `m.notice` choice, and when to render an HTML card to PNG. Ships seven references, three rendered HTML card templates (1200×630 / 1200×1500 / 1200×900), 12 evals, and a visual gallery. No scripts. ([#31](https://github.com/netresearch/matrix-skill/pull/31))
+- **`--notice` flag** on `matrix-send-e2ee.py` and `matrix-send.py` — sends `m.notice` instead of `m.text`, mutually exclusive with `--emote`. msgtype precedence: `notice > emote > text`. Closes the gap the announcement skill recommended but the transport scripts didn't support. ([#32](https://github.com/netresearch/matrix-skill/pull/32))
+
+### Changed
+
+- `matrix-send-e2ee.py` and `matrix-send.py`: `--emote` and `--notice` are now grouped via `argparse.add_mutually_exclusive_group`. The `send_message_e2ee()` and `send_message()` functions gained a `notice: bool = False` keyword parameter.
+- `matrix-communication` quick-reference, `messaging-guide.md`, and the root `AGENTS.md` cheat-sheet updated to document `--notice`.
+- `matrix-announcement/references/image-cards.md`: corrected guidance — `m.notice` is text-only; for an image announcement, send the card as `m.image` and a follow-up `m.text` via `--notice` rather than trying to flag the image event.
+
+## [1.21.1] - 2026-04-29
+
+Maintenance release: `matrix-administration` script harness improvements (10 → 18 checks), CI compatibility fixes, formatter robustness for pre-wrapped links and emphasis flanking.
+
+## [1.21.0] - 2026-04-26
+
+Quality overhaul of `matrix-administration`: 95% faster E2EE operations, 28 evals, expanded harness, full-text formatter improvements.
+
+## [1.20.1] - 2026-04-22
+
+Security patch: URL scheme validation before `urllib.urlopen` in `matrix-administration`.
+
+## [1.20.0] - 2026-04-16
+
+Added the **`matrix-administration` skill** — Synapse server operations (snapshot rooms, rate room health, render Graphviz map, force-join, promote, harden, deactivate, search history). Stdlib-only Python.
+
+---
+
+Older releases (before this changelog was introduced) are documented on the [releases page](https://github.com/netresearch/matrix-skill/releases).
+
+[Unreleased]: https://github.com/netresearch/matrix-skill/compare/v1.22.0...HEAD
+[1.22.0]: https://github.com/netresearch/matrix-skill/compare/v1.21.1...v1.22.0
+[1.21.1]: https://github.com/netresearch/matrix-skill/compare/v1.21.0...v1.21.1
+[1.21.0]: https://github.com/netresearch/matrix-skill/compare/v1.20.1...v1.21.0
+[1.20.1]: https://github.com/netresearch/matrix-skill/compare/v1.20.0...v1.20.1
+[1.20.0]: https://github.com/netresearch/matrix-skill/compare/v1.19.0...v1.20.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ For the canonical narrative version of each release (rewritten after CI publishe
 
 - `matrix-send-e2ee.py` and `matrix-send.py`: `--emote` and `--notice` are now grouped via `argparse.add_mutually_exclusive_group`. The `send_message_e2ee()` and `send_message()` functions gained a `notice: bool = False` keyword parameter.
 - `matrix-communication` quick-reference, `messaging-guide.md`, and the root `AGENTS.md` cheat-sheet updated to document `--notice`.
-- `matrix-announcement/references/image-cards.md`: corrected guidance — `m.notice` is text-only; for an image announcement, send the card as `m.image` and a follow-up `m.text` via `--notice` rather than trying to flag the image event.
+- `matrix-announcement/references/image-cards.md`: corrected guidance — `m.notice` is text-only; for an image announcement, send the card as `m.image` and a follow-up notice-flavour text message (msgtype `m.notice`, sent via `matrix-send-e2ee.py … --notice`) rather than trying to flag the image event itself as `m.notice`.
 
 ## [1.21.1] - 2026-04-29
 
@@ -37,7 +37,7 @@ Quality overhaul of `matrix-administration`: 95% faster E2EE operations, 28 eval
 
 ## [1.20.1] - 2026-04-22
 
-Security patch: URL scheme validation before `urllib.urlopen` in `matrix-administration`.
+Security patch: URL scheme validation before `urllib.request.urlopen` in `matrix-administration`.
 
 ## [1.20.0] - 2026-04-16
 


### PR DESCRIPTION
## Summary

Adds `CHANGELOG.md` (Keep-a-Changelog 1.1.0 format) seeded from v1.20.0–v1.22.0. Closes one of the three findings from `validate-pre-release.sh`. The other two are intentionally not addressed; reasoning below.

## What's in the changelog

- **`[Unreleased]`** section with empty subheader stubs (`Added` / `Changed` / `Fixed` / `Removed`) — this is the single source of changes during a release window. Going forward, the release-prep PR renames it to `[X.Y.Z] - YYYY-MM-DD` and adds a fresh empty `[Unreleased]` above.
- **Detailed entries** for v1.22.0 (the just-shipped release) — covers the new `matrix-announcement` skill and the `--notice` flag.
- **One-line summaries** for v1.20.0, v1.20.1, v1.21.0, v1.21.1 — back-fill enough for context.
- **Older releases** link to the [releases page](https://github.com/netresearch/matrix-skill/releases) rather than reconstructing from commit history; the canonical narrative for each release already lives there (rewritten by the release skill after CI publishes auto-generated notes).

## Pre-release-validator items deliberately NOT addressed

### `release.yml` permissions (`id-token:write`, `attestations:write`)

The reusable workflow at `netresearch/skill-repo-skill/.github/workflows/release.yml@main` uses neither `id-token` nor `attestations` actions today — no `actions/attest-build-provenance`, no cosign, no OIDC publish. Inspected sibling Netresearch skill repos (`github-release-skill`, `jira-skill`): neither grants those permissions either. Adding them in the caller without the reusable workflow using them would just silence the validator while adding nothing real, and would diverge from the org-wide convention.

The right place to add SLSA build provenance / cosign signing is `netresearch/skill-repo-skill` itself; the caller permissions follow naturally once the reusable actually needs them.

### Three lightweight tags (`v1.15.2`, `v1.17.1`, `v1.20.1`)

Re-tagging them as annotated would change the tag-ref SHA and break anyone (humans, CI caches, downstream mirrors, `composer.lock` checksums) holding the old SHA. The reusable release workflow already rejects lightweight tags going forward (verified in `skill-repo-skill/.github/workflows/release.yml`: it inspects `object.type` and exits non-zero if the tag is lightweight), so the policy is enforced for new releases. No reason to rewrite history.

## Verification

```
$ bash …/scripts/validate-pre-release.sh
Changelog:
  FAIL  CHANGELOG.md [Unreleased] has content (section is empty)   # normal — nothing pending
Branch:
  FAIL  On main/master branch (currently on chore/release-hardening)  # normal on feature branch
Release infrastructure:
  FAIL  Release workflow permissions (missing: id-token:write, attestations:write)  # see above
Tag integrity:
  FAIL  No lightweight version tags (3 lightweight tag(s) found)  # see above
```

The Changelog `[Unreleased]` and Branch fails are expected on a feature branch that ships no new functionality. After merge, on main, with no work-in-progress, `Changelog` becomes the only state-dependent FAIL — that's intended (the validator wants `[Unreleased]` to have content right before bumping the version).

## Test plan

- [ ] CI green on the PR
- [ ] `CHANGELOG.md` renders cleanly on the PR's "Files changed" tab
- [ ] After merge on main, `validate-pre-release.sh` shows 1 fewer FAIL than before
- [ ] On the next release PR (`chore: release vX.Y.Z`), the `[Unreleased]` rename pattern is followed