### PR TITLE
ci(release): opt in to SLSA build provenance attestations

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,8 @@ jobs:
     uses: netresearch/skill-repo-skill/.github/workflows/release.yml@main
     with:
       bump: ${{ inputs.bump }}
+      attest: true
     permissions:
-      contents: write
-      pull-requests: write
+      contents: write          # release upload
+      id-token: write          # OIDC for sigstore (required when attest: true)
+      attestations: write      # GitHub native attestation API (required when attest: true)


### PR DESCRIPTION
## Summary

Closes the `validate-pre-release.sh` finding *"Release workflow permissions (missing: id-token:write, attestations:write)"* by opting into the new SLSA build-provenance pipeline shipped in [netresearch/skill-repo-skill#78](https://github.com/netresearch/skill-repo-skill/pull/78).

That upstream PR added a non-breaking `attest: true` input to the reusable release workflow. When opted in, every release archive (zip + tar.gz) for every skill in the plugin gets a SLSA build-provenance attestation via `actions/attest-build-provenance@v4.1.0`, published to GitHub's native attestation API and verifiable with `gh attestation verify`.

## What changes

```diff
 jobs:
   release:
     uses: netresearch/skill-repo-skill/.github/workflows/release.yml@main
     with:
       bump: ${{ inputs.bump }}
+      attest: true
     permissions:
-      contents: write
-      pull-requests: write
+      contents: write          # release upload
+      id-token: write          # OIDC for sigstore (required when attest: true)
+      attestations: write      # GitHub native attestation API (required when attest: true)
```

- **`attest: true`** — turns on the new opt-in attestation job in the reusable workflow.
- **`id-token: write`** — OIDC token for sigstore. Required by `attest-build-provenance` to mint an in-toto statement.
- **`attestations: write`** — GitHub's native attestation API write scope.
- **Dropped `pull-requests: write`** — the reusable workflow doesn't touch the pulls API. Per Copilot review on the upstream PR, this was over-privileging. The previous bump job that DID create PRs was removed in skill-repo-skill before this; we should have dropped it then.

## Validation

```
$ bash …/scripts/validate-pre-release.sh
…
Release infrastructure:
  PASS  Release workflow exists (.github/workflows/release.yml)
  PASS  Release workflow permissions (id-token:write, attestations:write)
…
```

The remaining FAILs (`Changelog [Unreleased] empty`, `On main/master branch`, `Working tree clean`, `lightweight tags`) are unchanged from the previous status — `[Unreleased]` is empty because nothing's pending; the branch/working-tree fails are inherent to running on a feature branch; the lightweight-tag fails are the documented historical artefacts that the reusable workflow now blocks for new releases.

## Verification (post-merge, on the next release)

```bash
# Download an archive from the new release
gh release download vX.Y.Z -p '*-plugin-vX.Y.Z.zip' --repo netresearch/matrix-skill

# Verify the attestation
gh attestation verify matrix-communication-plugin-vX.Y.Z.zip --owner netresearch
```

Expected: SLSA v1.0 in-toto statement linking the archive's SHA256 to this workflow run, the merge commit, and the tag-push event. Failure modes are easy to diagnose: a permissions error in the `attest` job means the reusable's `attest: true` was passed without one of the two write scopes (this PR makes that impossible by granting both at the caller).

## Test plan

- [ ] CI green on this PR
- [ ] Merge → tag a documentation-only release (e.g. v1.22.1) → confirm the `attest` job runs, succeeds, and `gh attestation verify` passes against the released archive
- [ ] Confirm release publication itself is unaffected — the upstream design separates the `attest` job from `release` so a hypothetical attest failure cannot roll back a release