### PR TITLE
feat: ship as npm package via @netresearch/agent-skill-coordinator

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,24 @@ composer require netresearch/matrix-skill
 ```
 
 Requires [netresearch/composer-agent-skill-plugin](https://github.com/netresearch/composer-agent-skill-plugin).
+### npm (Node Projects)
+
+```bash
+npm install --save-dev \
+  @netresearch/agent-skill-coordinator \
+  github:netresearch/matrix-skill
+```
+
+Requires [@netresearch/agent-skill-coordinator](https://github.com/netresearch/node-agent-skill-coordinator), which discovers the skill in `node_modules` and registers it in `AGENTS.md` via a `postinstall` hook. For pnpm, also allowlist the coordinator's postinstall:
+
+```json
+{
+  "pnpm": {
+    "onlyBuiltDependencies": ["@netresearch/agent-skill-coordinator"]
+  }
+}
+```
+
 ## Prerequisites
 
 **For E2EE support** (most Matrix rooms), install libolm:

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,10 @@
         "netresearch/composer-agent-skill-plugin": "*"
     },
     "extra": {
-        "ai-agent-skill": "skills/matrix-communication/SKILL.md"
+        "ai-agent-skill": [
+            "skills/matrix-communication/SKILL.md",
+            "skills/matrix-administration/SKILL.md"
+        ]
     },
     "support": {
         "issues": "https://github.com/netresearch/matrix-skill/issues",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "skills/matrix-administration/SKILL.md"
   ],
   "files": [
+    ".claude-plugin/",
     "skills/matrix-communication/",
     "skills/matrix-administration/",
     "scripts/",

--- a/package.json
+++ b/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "@netresearch/matrix-skill",
+  "version": "0.0.0-source",
+  "description": "Netresearch AI skill for Matrix chat communication and homeserver administration.",
+  "license": "(MIT AND CC-BY-SA-4.0)",
+  "author": "Netresearch DTT GmbH (https://www.netresearch.de/)",
+  "homepage": "https://github.com/netresearch/matrix-skill",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/netresearch/matrix-skill.git"
+  },
+  "bugs": {
+    "url": "https://github.com/netresearch/matrix-skill/issues"
+  },
+  "keywords": [
+    "ai-agent-skill",
+    "matrix",
+    "chat",
+    "synapse",
+    "e2ee",
+    "anthropic",
+    "claude-code"
+  ],
+  "aiAgentSkill": "skills/matrix-communication/SKILL.md",
+  "files": [
+    "skills/matrix-communication/",
+    "skills/matrix-administration/",
+    "scripts/",
+    "LICENSE-MIT",
+    "LICENSE-CC-BY-SA-4.0",
+    "README.md"
+  ],
+  "peerDependencies": {
+    "@netresearch/agent-skill-coordinator": "^0.1"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -21,7 +21,10 @@
     "anthropic",
     "claude-code"
   ],
-  "aiAgentSkill": "skills/matrix-communication/SKILL.md",
+  "aiAgentSkill": [
+    "skills/matrix-communication/SKILL.md",
+    "skills/matrix-administration/SKILL.md"
+  ],
   "files": [
     "skills/matrix-communication/",
     "skills/matrix-administration/",


### PR DESCRIPTION
## Summary
- Adds `package.json` so the skill is npm-installable straight from this GitHub repo (no npm-registry publication required to start).
- README gains a parallel **npm (Node Projects)** section under Installation, mirroring the existing **Composer (PHP Projects)** section.

## How discovery works (consumer side)

```bash
npm install --save-dev \
  @netresearch/agent-skill-coordinator \
  github:netresearch/matrix-skill
```

After install, the coordinator's `postinstall` walks `node_modules`, finds this package via `aiAgentSkill: skills/matrix-communication/SKILL.md`, validates the frontmatter, and writes a `<skills_system>` block into the project's `AGENTS.md`. Same shape as the Composer plugin's output.

## Why version stays at `0.0.0-source`

Versioning still lives in git tags and the existing Composer release workflow. A real npm version would be set at publish time; until then, `0.0.0-source` is the standard "this manifest exists for tooling, not as a release marker" placeholder.

## Sibling PRs (merged)
- https://github.com/netresearch/git-workflow-skill/pull/39
- https://github.com/netresearch/github-project-skill/pull/67
- https://github.com/netresearch/security-audit-skill/pull/67

Coordinator: https://github.com/netresearch/node-agent-skill-coordinator (`@netresearch/agent-skill-coordinator@0.1.2`)