### PR TITLE
chore(release): v1.23.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "matrix-communication",
-  "version": "1.22.0",
+  "version": "1.23.0",
   "description": "Agentic Skills for Matrix: client-side chat (matrix-communication), Synapse homeserver administration (matrix-administration), and structured announcement composition (matrix-announcement). Works with any Matrix/Synapse homeserver.",
   "author": {
     "name": "Netresearch DTT GmbH",

--- a/skills/matrix-administration/SKILL.md
+++ b/skills/matrix-administration/SKILL.md
@@ -5,7 +5,7 @@ license: "(MIT AND CC-BY-SA-4.0). See LICENSE-MIT and LICENSE-CC-BY-SA-4.0"
 compatibility: "python3 (stdlib only) + a Matrix access token belonging to a Synapse server-admin user. Optional: graphviz `dot` for SVG. Synapse 1.x with admin API enabled."
 metadata:
   author: Netresearch DTT GmbH
-  version: "1.22.0"
+  version: "1.23.0"
   repository: https://github.com/netresearch/matrix-skill
 allowed-tools: Bash(python3:*) Bash(uv:*) Bash(dot:*) Read Write
 ---

--- a/skills/matrix-announcement/SKILL.md
+++ b/skills/matrix-announcement/SKILL.md
@@ -5,7 +5,7 @@ license: "(MIT AND CC-BY-SA-4.0). See LICENSE-MIT and LICENSE-CC-BY-SA-4.0"
 compatibility: "Pairs with matrix-communication for sending. Optional: headless Chromium for rendering HTML cards to PNG."
 metadata:
   author: Netresearch DTT GmbH
-  version: "1.22.0"
+  version: "1.23.0"
   repository: https://github.com/netresearch/matrix-skill
 allowed-tools: Bash(chromium:*) Bash(curl:*) Bash(jq:*) Read Write
 ---

--- a/skills/matrix-communication/SKILL.md
+++ b/skills/matrix-communication/SKILL.md
@@ -5,7 +5,7 @@ license: "(MIT AND CC-BY-SA-4.0). See LICENSE-MIT and LICENSE-CC-BY-SA-4.0"
 compatibility: "Requires python3, uv. Matrix homeserver access."
 metadata:
   author: Netresearch DTT GmbH
-  version: "1.22.0"
+  version: "1.23.0"
   repository: https://github.com/netresearch/matrix-skill
 allowed-tools: Bash(python3:*) Bash(uv:*) Read Write
 ---


### PR DESCRIPTION
## Release v1.23.0

Minor release. Bumps `.claude-plugin/plugin.json` and all three skills' `SKILL.md` frontmatter (`matrix-communication`, `matrix-administration`, `matrix-announcement`) from `1.22.0` to `1.23.0`. Picks up seven commits since `v1.22.0`.

### Highlights since v1.22.0

- `feat`: ship as an npm package via `@netresearch/agent-skill-coordinator`, giving JS/TS toolchains a parallel install path. Follow-ups declare both bundled skills (communication, administration) in `aiAgentSkill` / `extra.ai-agent-skill`, and the tarball now includes `.claude-plugin/plugin.json` for downstream loaders.
- `docs`: seeded CHANGELOG.md spanning `v1.20.0..v1.22.0` brings the public log up to current. Follow-up commit corrects accuracy issues surfaced in Copilot review on PR #34.
- `ci(release)`: opt in to SLSA build provenance attestations, drop the deprecated `with:` block + `workflow_dispatch.bump` input.

### Release plan

After merge: tag main with a signed annotated tag, push, the `skill-repo-skill` reusable workflow publishes archives + SHA256SUMS with cosign + SLSA attestation, then narrative notes get applied via `gh release edit ... --notes-file`.
