### PR TITLE
chore(release): v1.24.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "matrix-communication",
-  "version": "1.23.0",
+  "version": "1.24.0",
   "description": "Agentic Skills for Matrix: client-side chat (matrix-communication), Synapse homeserver administration (matrix-administration), and structured announcement composition (matrix-announcement). Works with any Matrix/Synapse homeserver.",
   "author": {
     "name": "Netresearch DTT GmbH",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ For the canonical narrative version of each release (rewritten after CI publishe
 
 ## [Unreleased]
 
+## [1.24.0] - 2026-05-28
+
 ### Added
 
 ### Changed

--- a/skills/matrix-administration/SKILL.md
+++ b/skills/matrix-administration/SKILL.md
@@ -5,7 +5,7 @@ license: "(MIT AND CC-BY-SA-4.0). See LICENSE-MIT and LICENSE-CC-BY-SA-4.0"
 compatibility: "python3 (stdlib only) + a Matrix access token belonging to a Synapse server-admin user. Optional: graphviz `dot` for SVG. Synapse 1.x with admin API enabled."
 metadata:
   author: Netresearch DTT GmbH
-  version: "1.23.0"
+  version: "1.24.0"
   repository: https://github.com/netresearch/matrix-skill
 allowed-tools: Bash(python3:*) Bash(uv:*) Bash(dot:*) Read Write
 ---

--- a/skills/matrix-announcement/SKILL.md
+++ b/skills/matrix-announcement/SKILL.md
@@ -5,7 +5,7 @@ license: "(MIT AND CC-BY-SA-4.0). See LICENSE-MIT and LICENSE-CC-BY-SA-4.0"
 compatibility: "Pairs with matrix-communication for sending. Optional: headless Chromium for rendering HTML cards to PNG."
 metadata:
   author: Netresearch DTT GmbH
-  version: "1.23.0"
+  version: "1.24.0"
   repository: https://github.com/netresearch/matrix-skill
 allowed-tools: Bash(chromium:*) Bash(curl:*) Bash(jq:*) Read Write
 ---

--- a/skills/matrix-communication/SKILL.md
+++ b/skills/matrix-communication/SKILL.md
@@ -5,7 +5,7 @@ license: "(MIT AND CC-BY-SA-4.0). See LICENSE-MIT and LICENSE-CC-BY-SA-4.0"
 compatibility: "Requires python3, uv. Matrix homeserver access."
 metadata:
   author: Netresearch DTT GmbH
-  version: "1.23.0"
+  version: "1.24.0"
   repository: https://github.com/netresearch/matrix-skill
 allowed-tools: Bash(python3:*) Bash(uv:*) Read Write
 ---


### PR DESCRIPTION
Release **v1.24.0** (minor bump, conventional commits since v1.23.0).

Bumps `.claude-plugin/plugin.json` + `SKILL.md` version to 1.24.0.

Changes since v1.23.0:
- feat: add .pre-commit-config.yaml mirroring CI checks
- 
- Wires netresearch/skill-repo-skill@v1.22.0 as a pre-commit hook
- provider so validate-skill, check-version-parity, and the standard
- linter set (markdownlint-cli2, yamllint, actionlint, ruff, shellcheck)
- run locally before commit instead of only in CI.
- - .yamllint.yml: matches the default config CI injects in the reusable
-   validate.yml workflow, so local and CI lint identically.
- - package.json scripts.prepare: invokes pre-commit install --install-hooks
-   if pre-commit is on PATH; silent no-op otherwise. Auto-activates hooks
-   on `npm install`.
- 
- Part of the fleet rollout following netresearch/agent-harness-skill#27
- (CI/Hook Parity Principle) and skill-repo-skill v1.22.0 (hook exposure).
- 
- Signed-off-by: Sebastian Mendel <info@sebastianmendel.de>
- feat: add .pre-commit-config.yaml mirroring CI checks (#39)
- 
- ## Summary
- 

After merge: a signed tag `v1.24.0` on `main` triggers the release workflow.