### PR TITLE
fix(communication): decrypt-error guidance + entity-linking rules for announcements

### DIFF
--- a/skills/matrix-announcement/SKILL.md
+++ b/skills/matrix-announcement/SKILL.md
@@ -43,7 +43,7 @@ One leading glyph at most. **Never** trailing decoration, multi-emoji ladders, �
 - [ ] Title fits on one line in Element on a 1280-wide screen.
 - [ ] First sentence states the change. No "we're excited to".
 - [ ] Every URL wrapped in `<a>` with destination-as-text.
-- [ ] Every entity is a link: issue keys (even mid-sentence), versions → release page, MRs/PRs as `project!N` / `repo#N`, pipelines, commits. Status updates: one item per line.
+- [ ] Every entity is a link: issue keys (even mid-sentence), versions → release page, MRs/PRs as `project!N` / `repo#N`, pipelines, commits. Status updates: one item per line, starting with the linked issue key, blank lines between items.
 - [ ] Every command, path, version is in `<code>`.
 - [ ] Multi-line code in `<pre><code class="language-…">`.
 - [ ] At most one prefix glyph; no trailing emoji; no celebration.

--- a/skills/matrix-announcement/SKILL.md
+++ b/skills/matrix-announcement/SKILL.md
@@ -43,7 +43,7 @@ One leading glyph at most. **Never** trailing decoration, multi-emoji ladders, �
 - [ ] Title fits on one line in Element on a 1280-wide screen.
 - [ ] First sentence states the change. No "we're excited to".
 - [ ] Every URL wrapped in `<a>` with destination-as-text.
-- [ ] Every entity is a link: issue keys (even mid-sentence), versions → release page, MRs/PRs as `project!N` / `repo#N`, pipelines, commits. Status updates: one item per line, starting with the linked issue key, blank lines between items.
+- [ ] Every entity is a link: issue keys (even mid-sentence), versions → release page, MRs/PRs as `project/path!N` / `org/repo#N`, pipelines, commits. Status updates: one item per line, starting with the linked issue key, blank lines between items.
 - [ ] Every command, path, version is in `<code>`.
 - [ ] Multi-line code in `<pre><code class="language-…">`.
 - [ ] At most one prefix glyph; no trailing emoji; no celebration.

--- a/skills/matrix-announcement/SKILL.md
+++ b/skills/matrix-announcement/SKILL.md
@@ -43,6 +43,7 @@ One leading glyph at most. **Never** trailing decoration, multi-emoji ladders, �
 - [ ] Title fits on one line in Element on a 1280-wide screen.
 - [ ] First sentence states the change. No "we're excited to".
 - [ ] Every URL wrapped in `<a>` with destination-as-text.
+- [ ] Every entity is a link: issue keys (even mid-sentence), versions → release page, MRs/PRs as `project!N` / `repo#N`, pipelines, commits. Status updates: one item per line.
 - [ ] Every command, path, version is in `<code>`.
 - [ ] Multi-line code in `<pre><code class="language-…">`.
 - [ ] At most one prefix glyph; no trailing emoji; no celebration.

--- a/skills/matrix-announcement/references/structure.md
+++ b/skills/matrix-announcement/references/structure.md
@@ -75,7 +75,18 @@ Render headings as `<strong>Heading:</strong>` on its own line, or `<h3>` if the
 
 The link text should be the destination's identity (ticket, repo, doc title), not a verb.
 
-## Length budget
+### Link every entity, not just "the" link
+
+Readers click the thing they are looking at — every linkable entity in the message body is a link, including incidental mentions:
+
+- **Issue keys** — every occurrence, even mid-sentence context ("blockers from <a href="…/SRVC-99">SRVC-99</a> cleared"), not only the headline ticket.
+- **Version numbers** — link to their release page: `traefik <a href="…/releases/tag/v3.7.1">3.7.1</a>→<a href="…/releases/tag/v3.7.4">3.7.4</a>`. A version without its release notes makes the reader search for them.
+- **MRs / PRs** — use the platform's reference notation as text: GitLab `<a href="…">project/path!30</a>`, GitHub `<a href="…">org/repo#42</a>`. Never bare "MR !30" — it is ambiguous across projects and unclickable when copied.
+- **Pipelines, commits, tags, branches** — same rule: identity as text, URL behind it.
+
+### Status updates: one item per line
+
+Multi-item progress posts (maintenance logs, digest-style updates) get one line per ticket/work item, separated by blank lines, each line starting with the linked issue key. Readers scan for *their* item; interleaved prose hides it.
 
 | Metric | Target | Hard limit |
 | --- | --- | --- |

--- a/skills/matrix-announcement/references/structure.md
+++ b/skills/matrix-announcement/references/structure.md
@@ -80,13 +80,15 @@ The link text should be the destination's identity (ticket, repo, doc title), no
 Readers click the thing they are looking at — every linkable entity in the message body is a link, including incidental mentions:
 
 - **Issue keys** — every occurrence, even mid-sentence context ("blockers from <a href="…/SRVC-99">SRVC-99</a> cleared"), not only the headline ticket.
-- **Version numbers** — link to their release page: `traefik <a href="…/releases/tag/v3.7.1">3.7.1</a>→<a href="…/releases/tag/v3.7.4">3.7.4</a>`. A version without its release notes makes the reader search for them.
+- **Version numbers** — link to their release page, keeping the version in `<code>` inside the link: `traefik <a href="…/releases/tag/v3.7.1"><code>3.7.1</code></a>→<a href="…/releases/tag/v3.7.4"><code>3.7.4</code></a>`. A version without its release notes makes the reader search for them.
 - **MRs / PRs** — use the platform's reference notation as text: GitLab `<a href="…">project/path!30</a>`, GitHub `<a href="…">org/repo#42</a>`. Never bare "MR !30" — it is ambiguous across projects and unclickable when copied.
 - **Pipelines, commits, tags, branches** — same rule: identity as text, URL behind it.
 
 ### Status updates: one item per line
 
 Multi-item progress posts (maintenance logs, digest-style updates) get one line per ticket/work item, separated by blank lines, each line starting with the linked issue key. Readers scan for *their* item; interleaved prose hides it.
+
+## Length budget
 
 | Metric | Target | Hard limit |
 | --- | --- | --- |

--- a/skills/matrix-announcement/references/structure.md
+++ b/skills/matrix-announcement/references/structure.md
@@ -79,7 +79,7 @@ The link text should be the destination's identity (ticket, repo, doc title), no
 
 Readers click the thing they are looking at — every linkable entity in the message body is a link, including incidental mentions:
 
-- **Issue keys** — every occurrence, even mid-sentence context ("blockers from <a href="…/SRVC-99">SRVC-99</a> cleared"), not only the headline ticket.
+- **Issue keys** — every occurrence, even mid-sentence context (`blockers from <a href="…/SRVC-99">SRVC-99</a> cleared`), not only the headline ticket.
 - **Version numbers** — link to their release page, keeping the version in `<code>` inside the link: `traefik <a href="…/releases/tag/v3.7.1"><code>3.7.1</code></a>→<a href="…/releases/tag/v3.7.4"><code>3.7.4</code></a>`. A version without its release notes makes the reader search for them.
 - **MRs / PRs** — use the platform's reference notation as text: GitLab `<a href="…">project/path!30</a>`, GitHub `<a href="…">org/repo#42</a>`. Never bare "MR !30" — it is ambiguous across projects and unclickable when copied.
 - **Pipelines, commits, tags, branches** — same rule: identity as text, URL behind it.

--- a/skills/matrix-communication/SKILL.md
+++ b/skills/matrix-communication/SKILL.md
@@ -82,7 +82,7 @@ Other: `matrix-rooms.py`, `matrix-resolve.py`, `matrix-e2ee-setup.py`, `matrix-e
 | `M_UNKNOWN_TOKEN` | Get new token from Element |
 | `M_LIMIT_EXCEEDED` | Wait and retry |
 | `Could not find room` | `matrix-rooms.py` to list rooms |
-| `[Unable to decrypt]` | First: `matrix-fetch-keys.py ROOM --sync-time 60` (requests keys from other devices, no recovery key needed); fallback: `matrix-key-backup.py --recovery-key "..." --import-keys` |
+| `[Unable to decrypt]` | First: `uv run ${CLAUDE_SKILL_DIR}/scripts/matrix-fetch-keys.py ROOM --sync-time 60` (requests keys from other devices, no recovery key needed); fallback: `uv run ${CLAUDE_SKILL_DIR}/scripts/matrix-key-backup.py --recovery-key "..." --import-keys` |
 | `libolm not found` | `apt install libolm-dev` / `brew install libolm` |
 | `matrix-nio not found` | `python3 ${CLAUDE_SKILL_DIR}/scripts/matrix-doctor.py --install` |
 | `Invalid password` | Use env var: `MATRIX_PASSWORD="pass" uv run ...` |

--- a/skills/matrix-communication/SKILL.md
+++ b/skills/matrix-communication/SKILL.md
@@ -82,7 +82,7 @@ Other: `matrix-rooms.py`, `matrix-resolve.py`, `matrix-e2ee-setup.py`, `matrix-e
 | `M_UNKNOWN_TOKEN` | Get new token from Element |
 | `M_LIMIT_EXCEEDED` | Wait and retry |
 | `Could not find room` | `matrix-rooms.py` to list rooms |
-| `[Unable to decrypt]` | `matrix-key-backup.py --recovery-key "..." --import-keys` |
+| `[Unable to decrypt]` | First: `matrix-fetch-keys.py ROOM --sync-time 60` (requests keys from other devices, no recovery key needed); fallback: `matrix-key-backup.py --recovery-key "..." --import-keys` |
 | `libolm not found` | `apt install libolm-dev` / `brew install libolm` |
 | `matrix-nio not found` | `python3 ${CLAUDE_SKILL_DIR}/scripts/matrix-doctor.py --install` |
 | `Invalid password` | Use env var: `MATRIX_PASSWORD="pass" uv run ...` |


### PR DESCRIPTION
## What

Two retro findings from live use during the 2026-06-10 maintenance window (NRS-4445):

1. **matrix-communication error table**: `[Unable to decrypt]` now recommends `matrix-fetch-keys.py ROOM --sync-time 60` first — it resolves the common missing-room-keys case with no recovery key (verified live: 380 keys received, room readable). The key-backup import remains as fallback.

2. **matrix-announcement linking rules**: new `structure.md` section *Link every entity, not just "the" link* + pre-send checklist item, encoding reviewer feedback given three times in one session:
   - every issue key linked, including incidental mid-sentence mentions
   - version numbers link to their release page
   - MRs/PRs written in platform reference notation (`project/path!30`, `org/repo#42`) as link text
   - multi-item status updates: one linked item per line, blank lines between

## Why

Agents composing room posts under-link by default; these rules came from a human reviewer correcting live maintenance comms (three rounds of corrections, then a rework of all posted messages). Encoding them here makes them team-wide instead of one user's memory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)