### PR TITLE
chore(release): v1.25.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "matrix-communication",
-  "version": "1.24.0",
+  "version": "1.25.0",
   "description": "Agentic Skills for Matrix: client-side chat (matrix-communication), Synapse homeserver administration (matrix-administration), and structured announcement composition (matrix-announcement). Works with any Matrix/Synapse homeserver.",
   "author": {
     "name": "Netresearch DTT GmbH",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,16 @@ For the canonical narrative version of each release (rewritten after CI publishe
 
 ### Removed
 
+
+## [1.23.0] - 2026-05-15
+
+### Added
+
+- Ship as npm package via `@netresearch/agent-skill-coordinator` ([#37](https://github.com/netresearch/matrix-skill/pull/37))
+
+### Fixed
+
+- Declare both matrix skills in `aiAgentSkill` / `extra.ai-agent-skill`; include `.claude-plugin/plugin.json` in the npm tarball ([#37](https://github.com/netresearch/matrix-skill/pull/37))
 ## [1.22.0] - 2026-04-29
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ For the canonical narrative version of each release (rewritten after CI publishe
 
 ## [Unreleased]
 
+## [1.25.0] - 2026-06-10
+
+### Added
+
+- matrix-announcement: entity-linking rules (every issue key linked, versions link to their release page, MRs/PRs in `project/path!N` / `org/repo#N` notation) and one-item-per-line status-update layout ([#41](https://github.com/netresearch/matrix-skill/pull/41))
+
+### Fixed
+
+- matrix-communication: `[Unable to decrypt]` guidance now recommends `matrix-fetch-keys.py` first — resolves the common missing-room-keys case without a recovery key ([#41](https://github.com/netresearch/matrix-skill/pull/41))
+
 ## [1.24.0] - 2026-05-28
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,7 +59,10 @@ Added the **`matrix-administration` skill** — Synapse server operations (snaps
 
 Older releases (before this changelog was introduced) are documented on the [releases page](https://github.com/netresearch/matrix-skill/releases).
 
-[Unreleased]: https://github.com/netresearch/matrix-skill/compare/v1.22.0...HEAD
+[Unreleased]: https://github.com/netresearch/matrix-skill/compare/v1.25.0...HEAD
+[1.25.0]: https://github.com/netresearch/matrix-skill/compare/v1.24.0...v1.25.0
+[1.24.0]: https://github.com/netresearch/matrix-skill/compare/v1.23.0...v1.24.0
+[1.23.0]: https://github.com/netresearch/matrix-skill/compare/v1.22.0...v1.23.0
 [1.22.0]: https://github.com/netresearch/matrix-skill/compare/v1.21.1...v1.22.0
 [1.21.1]: https://github.com/netresearch/matrix-skill/compare/v1.21.0...v1.21.1
 [1.21.0]: https://github.com/netresearch/matrix-skill/compare/v1.20.1...v1.21.0

--- a/skills/matrix-administration/SKILL.md
+++ b/skills/matrix-administration/SKILL.md
@@ -5,7 +5,7 @@ license: "(MIT AND CC-BY-SA-4.0). See LICENSE-MIT and LICENSE-CC-BY-SA-4.0"
 compatibility: "python3 (stdlib only) + a Matrix access token belonging to a Synapse server-admin user. Optional: graphviz `dot` for SVG. Synapse 1.x with admin API enabled."
 metadata:
   author: Netresearch DTT GmbH
-  version: "1.24.0"
+  version: "1.25.0"
   repository: https://github.com/netresearch/matrix-skill
 allowed-tools: Bash(python3:*) Bash(uv:*) Bash(dot:*) Read Write
 ---

--- a/skills/matrix-announcement/SKILL.md
+++ b/skills/matrix-announcement/SKILL.md
@@ -5,7 +5,7 @@ license: "(MIT AND CC-BY-SA-4.0). See LICENSE-MIT and LICENSE-CC-BY-SA-4.0"
 compatibility: "Pairs with matrix-communication for sending. Optional: headless Chromium for rendering HTML cards to PNG."
 metadata:
   author: Netresearch DTT GmbH
-  version: "1.24.0"
+  version: "1.25.0"
   repository: https://github.com/netresearch/matrix-skill
 allowed-tools: Bash(chromium:*) Bash(curl:*) Bash(jq:*) Read Write
 ---

--- a/skills/matrix-communication/SKILL.md
+++ b/skills/matrix-communication/SKILL.md
@@ -5,7 +5,7 @@ license: "(MIT AND CC-BY-SA-4.0). See LICENSE-MIT and LICENSE-CC-BY-SA-4.0"
 compatibility: "Requires python3, uv. Matrix homeserver access."
 metadata:
   author: Netresearch DTT GmbH
-  version: "1.24.0"
+  version: "1.25.0"
   repository: https://github.com/netresearch/matrix-skill
 allowed-tools: Bash(python3:*) Bash(uv:*) Read Write
 ---


### PR DESCRIPTION
Release v1.25.0 — #41:

- **Added** (matrix-announcement): entity-linking rules (issue keys, versions → release pages, `project/path!N` / `org/repo#N` notation) and one-item-per-line status updates
- **Fixed** (matrix-communication): `[Unable to decrypt]` now recommends `matrix-fetch-keys.py` first (no recovery key needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)