### PR TITLE
fix(matrix-communication): correct misleading libolm/brew guidance on macOS (#43)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ For the canonical narrative version of each release (rewritten after CI publishe
 
 ## [Unreleased]
 
+### Fixed
+
+- matrix-communication: corrected misleading `brew install libolm` guidance in the setup guide and `_lib/deps.py` runtime error — `python-olm` has no macOS wheel and statically links its own bundled `libolm`, so Homebrew's library is never used. Documented the macOS 26 (Tahoe) / Apple Clang 17 build failure, a community-reported build-from-source workaround (GCC + `CMAKE_POLICY_VERSION_MINIMUM`), and the upstream status (libolm deprecated; vodozemac migration in `matrix-nio` PR [#555](https://github.com/matrix-nio/matrix-nio/pull/555)) ([#43](https://github.com/netresearch/matrix-skill/issues/43))
+
 ## [1.25.0] - 2026-06-10
 
 ### Added

--- a/skills/matrix-communication/SKILL.md
+++ b/skills/matrix-communication/SKILL.md
@@ -83,7 +83,7 @@ Other: `matrix-rooms.py`, `matrix-resolve.py`, `matrix-e2ee-setup.py`, `matrix-e
 | `M_LIMIT_EXCEEDED` | Wait and retry |
 | `Could not find room` | `matrix-rooms.py` to list rooms |
 | `[Unable to decrypt]` | First: `uv run ${CLAUDE_SKILL_DIR}/scripts/matrix-fetch-keys.py ROOM --sync-time 60` (requests keys from other devices, no recovery key needed); fallback: `uv run ${CLAUDE_SKILL_DIR}/scripts/matrix-key-backup.py --recovery-key "..." --import-keys` |
-| `libolm not found` | `apt install libolm-dev` / `brew install libolm` |
+| `libolm not found` | Linux: `apt install libolm-dev`; macOS 26+ unsupported (see `references/setup-guide.md`) |
 | `matrix-nio not found` | `python3 ${CLAUDE_SKILL_DIR}/scripts/matrix-doctor.py --install` |
 | `Invalid password` | Use env var: `MATRIX_PASSWORD="pass" uv run ...` |
 | `signature failed` | Dedicated device via `matrix-e2ee-setup.py` |

--- a/skills/matrix-communication/references/setup-guide.md
+++ b/skills/matrix-communication/references/setup-guide.md
@@ -16,7 +16,7 @@ python3 skills/matrix-communication/scripts/matrix-doctor.py --install
 
 **Required for E2EE:**
 - `matrix-nio[e2e]` - Matrix client library with encryption support
-- `libolm` - System library for Olm encryption (install via apt/dnf/brew)
+- `libolm` - Olm encryption library, bundled and compiled by `python-olm` (Linux installs a pre-built wheel; **macOS 26+ is unsupported**, see Troubleshooting)
 
 **Package manager priority:** The doctor script tries: `uvx pip` > `uv pip` > `pip` > `pip3`
 
@@ -154,10 +154,27 @@ sudo apt install libolm-dev
 
 # Fedora
 sudo dnf install libolm-devel
-
-# macOS
-brew install libolm
 ```
+
+**macOS 26 (Tahoe) / Apple Clang 17 — `brew install libolm` does NOT help.**
+
+`matrix-nio[e2e]` pulls in `python-olm`, which has **no macOS wheel** on PyPI and compiles a *bundled* copy of `libolm` from source, statically linked — it never uses the Homebrew library. That bundled build fails under Apple Clang 17 / CMake ≥ 3.30 (a C++ const-correctness hard error in `list.hh`, plus an obsolete `cmake_minimum_required(VERSION 3.4)`).
+
+Workarounds, easiest first:
+
+- Use the **non-E2EE scripts** (`matrix-send.py`, `matrix-rooms.py`, …) — they don't need `python-olm`.
+- Run the **E2EE scripts from Linux or a Linux container**, where the pre-built wheel installs cleanly.
+- Build `python-olm` on macOS with **GCC instead of Clang** (community-reported in https://github.com/matrix-nio/matrix-nio/issues/541; not verified by this project):
+
+```bash
+brew install gcc@12
+export CC=/opt/homebrew/bin/gcc-12
+export CXX=/opt/homebrew/bin/g++-12
+export CMAKE_POLICY_VERSION_MINIMUM=3.5   # clears the CMake < 3.5 error
+pip install 'matrix-nio[e2e]'             # GCC sidesteps the Clang 17 const error
+```
+
+**Upstream status:** `libolm` is archived and deprecated in favor of `vodozemac` (https://github.com/matrix-nio/matrix-nio/issues/518). The real fix — replacing olm with vodozemac in `matrix-nio` — is in progress as open PR https://github.com/matrix-nio/matrix-nio/pull/555; until it ships, macOS installs need one of the workarounds above. Related: https://github.com/matrix-nio/matrix-nio/issues/560 (macOS install) and https://github.com/matrix-nio/matrix-nio/issues/541 (CMake error). Tracking here: https://github.com/netresearch/matrix-skill/issues/43
 
 **Non-E2EE scripts fail with "Config missing required fields: access_token":**
 

--- a/skills/matrix-communication/scripts/_lib/deps.py
+++ b/skills/matrix-communication/scripts/_lib/deps.py
@@ -25,7 +25,8 @@ def check_e2ee_dependencies() -> None:
             print("Install libolm for your platform:", file=sys.stderr)
             print("  Debian/Ubuntu: sudo apt install libolm-dev", file=sys.stderr)
             print("  Fedora:        sudo dnf install libolm-devel", file=sys.stderr)
-            print("  macOS:         brew install libolm", file=sys.stderr)
+            print("  macOS 26+:     brew won't help; python-olm", file=sys.stderr)
+            print("    build fails (Clang 17), see setup-guide.md.", file=sys.stderr)
         elif "nio" in error_msg or "matrix" in error_msg:
             print("Error: matrix-nio library not found.", file=sys.stderr)
             print("", file=sys.stderr)

--- a/skills/matrix-communication/scripts/matrix-e2ee-setup.py
+++ b/skills/matrix-communication/scripts/matrix-e2ee-setup.py
@@ -11,7 +11,7 @@ Run once to set up E2EE, then matrix-send-e2ee.py works without password.
 Requires libolm system library:
     Debian/Ubuntu: sudo apt install libolm-dev
     Fedora:        sudo dnf install libolm-devel
-    macOS:         brew install libolm
+    macOS 26+:     unsupported, python-olm build fails (Clang 17); see setup-guide.md
 
 Usage:
     matrix-e2ee-setup.py              # Interactive password prompt

--- a/skills/matrix-communication/scripts/matrix-read-e2ee.py
+++ b/skills/matrix-communication/scripts/matrix-read-e2ee.py
@@ -8,7 +8,7 @@
 Requires libolm system library:
     Debian/Ubuntu: sudo apt install libolm-dev
     Fedora:        sudo dnf install libolm-devel
-    macOS:         brew install libolm
+    macOS 26+:     unsupported, python-olm build fails (Clang 17); see setup-guide.md
 
 Usage:
     matrix-read-e2ee.py ROOM [--limit N] [--json] [--request-keys]

--- a/skills/matrix-communication/scripts/matrix-send-e2ee.py
+++ b/skills/matrix-communication/scripts/matrix-send-e2ee.py
@@ -8,7 +8,7 @@
 Requires libolm system library:
     Debian/Ubuntu: sudo apt install libolm-dev
     Fedora:        sudo dnf install libolm-devel
-    macOS:         brew install libolm
+    macOS 26+:     unsupported, python-olm build fails (Clang 17); see setup-guide.md
 
 Usage:
     matrix-send-e2ee.py ROOM MESSAGE [OPTIONS]


### PR DESCRIPTION
## What

Corrects the misleading `brew install libolm` guidance for macOS, documents the macOS 26 (Tahoe) / Apple Clang 17 build failure reported in #43, adds a community-reported build-from-source workaround, and links the live upstream trackers.

## Why

`matrix-nio[e2e]` depends on `python-olm`, which ships **no macOS wheel** on PyPI — so on macOS it always builds from the sdist. The sdist bundles a vendored copy of `libolm` and `olm_build.py` compiles it (`cmake . -Bbuild -DBUILD_SHARED_LIBS=NO`, falling back to `make static`) and **statically links its own copy**. The Homebrew `libolm` is never consulted, so `brew install libolm` cannot fix anything. On macOS 26 with Apple Clang 17 / CMake ≥ 3.30 that bundled build fails outright (a C++ const-correctness hard error in `list.hh`, plus an obsolete `cmake_minimum_required(VERSION 3.4)`).

Verified against the actual `python-olm` 3.2.16 sdist — see https://github.com/netresearch/matrix-skill/issues/43#issuecomment-4712180206

## Changes

- `references/setup-guide.md`: replaced the macOS `brew install libolm` line with an accurate macOS 26 / Clang 17 section — workarounds (non-E2EE scripts; run from Linux/a container; or build with GCC) plus upstream status and links.
- `SKILL.md`: troubleshooting table row for `libolm not found` no longer recommends `brew install libolm` on macOS.
- `scripts/_lib/deps.py`: runtime error message for missing olm now states the macOS situation instead of suggesting brew.
- `scripts/matrix-send-e2ee.py`, `matrix-e2ee-setup.py`, `matrix-read-e2ee.py`: docstring headers updated to match.
- `CHANGELOG.md`: entry under Unreleased.

## Workaround documented for affected users

Community-reported in https://github.com/matrix-nio/matrix-nio/issues/541 (not verified by this project) — build `python-olm` with GCC instead of Clang:

```bash
brew install gcc@12
export CC=/opt/homebrew/bin/gcc-12
export CXX=/opt/homebrew/bin/g++-12
export CMAKE_POLICY_VERSION_MINIMUM=3.5   # clears the CMake < 3.5 error
pip install 'matrix-nio[e2e]'             # GCC sidesteps the Clang 17 const error
```

Plus the always-available fallbacks: use the non-E2EE scripts, or run the E2EE scripts from Linux / a container.

## Upstream status

`libolm` is archived and deprecated in favor of `vodozemac` (https://github.com/matrix-nio/matrix-nio/issues/518). The real fix — replacing olm with vodozemac in `matrix-nio` — is in progress as **open PR https://github.com/matrix-nio/matrix-nio/pull/555**. Related install reports: https://github.com/matrix-nio/matrix-nio/issues/560 (macOS) and https://github.com/matrix-nio/matrix-nio/issues/541 (CMake).

## Scope

Docs/guidance only — this does **not** fix the upstream build and does **not** close #43. Tracking stays open until matrix-nio#555 lands and ships (or a patched `python-olm` with macOS wheels appears).

Refs #43