### PR TITLE
docs(admin-api): room-IDs without :server suffix + admin messages endpoint

### DIFF
--- a/skills/matrix-administration/references/synapse-admin-api.md
+++ b/skills/matrix-administration/references/synapse-admin-api.md
@@ -15,6 +15,7 @@ Upstream docs: <https://element-hq.github.io/synapse/latest/usage/administration
 | `GET /v1/rooms/{room_id}/state` | `synapse-fetch-rooms.py` | All current state events. |
 | `POST /v1/rooms/{room_id}/make_room_admin` | `synapse-make-admin.py`, `synapse-migrate-room.py` | Body: `{"user_id": "@..."}`. Requires another admin to still be present. |
 | `POST /v1/join/{room_id}` | `synapse-join-room.py` | Body: `{"user_id": "@..."}`. |
+| `GET /v1/rooms/{room_id}/messages?dir=b&limit=N` | (ad-hoc timeline reads) | Reads a room's timeline **without joining** — unlike the Client-Server `/messages` endpoint, which 403s for rooms the token's user isn't in. Returns `chunk[]`. `from` is **optional** here (the admin endpoint defaults it, unlike the CS endpoint); pass `from`/`to` only to paginate. |
 
 ## Users
 
@@ -41,6 +42,12 @@ The admin user must be a member of the target room for state writes.
 | `POST /rooms/{room_id}/join` | `synapse-migrate-room.py` | Joins the calling user. |
 | `GET /rooms/{room_id}/context/{event_id}?filter=...&limit=1` | `synapse-room-member-flow.py` | Used to recover the previous state event a leave/kick replaced. |
 | `POST /search` | `synapse-search.py` | Body: room-event search payload, paginated via `next_batch`. |
+
+## Room-ID gotcha: newer rooms have no `:server` suffix
+
+Room IDs are not always `!localpart:server`. Room version 12+ (hash-based IDs) can be just `!<hash>` with **no `:server` suffix** — e.g. `!vqqacuaPMN-dV0WHbz4ISOzOCws8HX0EWZ7UphUoiCQ`. Use the `room_id` **verbatim** as returned by `GET /v1/rooms` / `rooms.json`; never append a server part.
+
+If you do append `:server` to such an id, the admin room endpoints (`GET /v1/rooms/{room_id}/messages`, `/state`, …) return an **empty result rather than a 404** — so it looks like "the room has no messages" when the room is fine and you simply addressed a non-existent id. Symptom: a messages fetch or `synapse-search.py` returns nothing for a room you *know* is active. Fix: copy the exact `room_id` from the snapshot, unmodified.
 
 ## Encryption note
 


### PR DESCRIPTION
Two additions to `skills/matrix-administration/references/synapse-admin-api.md`, both hit live this session:

- **Room-ID gotcha** — room version 12+ IDs are `!<hash>` with **no `:server` suffix**. Appending one makes the admin room endpoints (`/messages`, `/state`) return an **empty result, not a 404** — looks like 'the room has no messages' when the id is simply wrong. Use the `room_id` verbatim from the snapshot.
- **`GET /v1/rooms/{id}/messages`** added to the Rooms table — reads a room's timeline **without joining**, unlike the Client-Server `/messages` endpoint which 403s for non-member rooms.

Docs-only; no script or SKILL.md change.