### PR TITLE
chore(release): v1.25.1

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "matrix-communication",
-  "version": "1.25.0",
+  "version": "1.25.1",
   "description": "Agentic Skills for Matrix: client-side chat (matrix-communication), Synapse homeserver administration (matrix-administration), and structured announcement composition (matrix-announcement). Works with any Matrix/Synapse homeserver.",
   "author": {
     "name": "Netresearch DTT GmbH",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,15 @@ For the canonical narrative version of each release (rewritten after CI publishe
 
 ## [Unreleased]
 
+## [1.25.1] - 2026-06-18
+
 ### Fixed
 
 - matrix-communication: corrected misleading `brew install libolm` guidance in the setup guide and `_lib/deps.py` runtime error — `python-olm` has no macOS wheel and statically links its own bundled `libolm`, so Homebrew's library is never used. Documented the macOS 26 (Tahoe) / Apple Clang 17 build failure, a community-reported build-from-source workaround (GCC + `CMAKE_POLICY_VERSION_MINIMUM`), and the upstream status (libolm deprecated; vodozemac migration in `matrix-nio` PR [#555](https://github.com/matrix-nio/matrix-nio/pull/555)) ([#43](https://github.com/netresearch/matrix-skill/issues/43))
+
+### Documentation
+
+- matrix-administration: documented that room IDs may be passed without the `:server` suffix, and added the Synapse admin messages endpoint to the admin-API reference ([#45](https://github.com/netresearch/matrix-skill/pull/45)).
 
 ## [1.25.0] - 2026-06-10
 

--- a/skills/matrix-administration/SKILL.md
+++ b/skills/matrix-administration/SKILL.md
@@ -5,7 +5,7 @@ license: "(MIT AND CC-BY-SA-4.0). See LICENSE-MIT and LICENSE-CC-BY-SA-4.0"
 compatibility: "python3 (stdlib only) + a Matrix access token belonging to a Synapse server-admin user. Optional: graphviz `dot` for SVG. Synapse 1.x with admin API enabled."
 metadata:
   author: Netresearch DTT GmbH
-  version: "1.25.0"
+  version: "1.25.1"
   repository: https://github.com/netresearch/matrix-skill
 allowed-tools: Bash(python3:*) Bash(uv:*) Bash(dot:*) Read Write
 ---

--- a/skills/matrix-announcement/SKILL.md
+++ b/skills/matrix-announcement/SKILL.md
@@ -5,7 +5,7 @@ license: "(MIT AND CC-BY-SA-4.0). See LICENSE-MIT and LICENSE-CC-BY-SA-4.0"
 compatibility: "Pairs with matrix-communication for sending. Optional: headless Chromium for rendering HTML cards to PNG."
 metadata:
   author: Netresearch DTT GmbH
-  version: "1.25.0"
+  version: "1.25.1"
   repository: https://github.com/netresearch/matrix-skill
 allowed-tools: Bash(chromium:*) Bash(curl:*) Bash(jq:*) Read Write
 ---

--- a/skills/matrix-communication/SKILL.md
+++ b/skills/matrix-communication/SKILL.md
@@ -5,7 +5,7 @@ license: "(MIT AND CC-BY-SA-4.0). See LICENSE-MIT and LICENSE-CC-BY-SA-4.0"
 compatibility: "Requires python3, uv. Matrix homeserver access."
 metadata:
   author: Netresearch DTT GmbH
-  version: "1.25.0"
+  version: "1.25.1"
   repository: https://github.com/netresearch/matrix-skill
 allowed-tools: Bash(python3:*) Bash(uv:*) Read Write
 ---


### PR DESCRIPTION
Release v1.25.1 — patch.

Bumps plugin.json + matrix-administration/-announcement/-communication SKILL.md metadata 1.25.0 → 1.25.1 and promotes the CHANGELOG [Unreleased] section.

### Fixed
- matrix-communication: corrected misleading macOS `libolm` install guidance (no macOS wheel; bundled static lib) (#43)
### Documentation
- matrix-administration: room IDs without `:server` suffix + admin messages endpoint (#45)