### PR TITLE
fix(matrix-communication): don't report verify success on MAC mismatch; fetch keys in --listen

### DIFF
--- a/skills/matrix-communication/scripts/matrix-e2ee-verify.py
+++ b/skills/matrix-communication/scripts/matrix-e2ee-verify.py
@@ -314,27 +314,35 @@ async def fetch_room_keys(client):
     """
     print("\n📦 Fetching room keys from verified devices...")
 
-    rooms_checked = 0
-    for room_id, room in list(client.rooms.items())[:10]:
-        if room.encrypted:
-            rooms_checked += 1
-            try:
-                result = await client.room_messages(room_id, start="", limit=50)
-                if isinstance(result, RoomMessagesResponse):
-                    for event in result.chunk:
-                        if isinstance(event, MegolmEvent):
-                            try:
-                                await client.request_room_key(event)
-                            except Exception:
-                                pass
-            except Exception:
-                pass
+    # Filter to encrypted rooms *before* limiting, so we always look at up to 10
+    # encrypted rooms rather than 10 arbitrary rooms that might all be unencrypted.
+    encrypted_rooms = [
+        (room_id, room) for room_id, room in client.rooms.items() if room.encrypted
+    ][:10]
+    rooms_checked = len(encrypted_rooms)
+    for room_id, room in encrypted_rooms:
+        try:
+            result = await client.room_messages(room_id, start="", limit=50)
+            if isinstance(result, RoomMessagesResponse):
+                for event in result.chunk:
+                    if isinstance(event, MegolmEvent):
+                        try:
+                            await client.request_room_key(event)
+                        except Exception:
+                            pass
+        except Exception:
+            pass
 
     print(f"   Checked {rooms_checked} encrypted rooms")
     print("   Waiting for keys (30s)...")
 
     for i in range(6):
-        await client.sync(timeout=5000)
+        # Verification already succeeded; a transient sync error here must not
+        # crash the script or mask that success.
+        try:
+            await client.sync(timeout=5000)
+        except Exception:
+            pass
         if (i + 1) % 2 == 0:
             print(f"   ... {(i + 1) * 5}s")
 

--- a/skills/matrix-communication/scripts/matrix-e2ee-verify.py
+++ b/skills/matrix-communication/scripts/matrix-e2ee-verify.py
@@ -243,10 +243,34 @@ class VerificationHandler:
                         else sas.other_olm_device.device_id
                     )
 
-                    # Always send done — Element requires it regardless of sas.verified.
-                    # The nio SAS state machine can land in SasState.canceled after a
-                    # successful MAC exchange (race in the state machine), keeping
-                    # sas.verified False even though both sides completed the exchange.
+                    # nio's receive_mac_event never raises on a bad MAC — it
+                    # silently sets the SAS state to SasState.canceled. sas.verified
+                    # can also be False after a *successful* MAC exchange due to a
+                    # race in nio's state machine, so it alone cannot tell a genuine
+                    # key mismatch from the benign race. verified_devices is the
+                    # authoritative signal: a device id lands there only once its MAC
+                    # has been cryptographically validated, and a later cancel does
+                    # not clear it.
+                    mac_ok = sas.verified or other_device in getattr(
+                        sas, "verified_devices", []
+                    )
+
+                    if not mac_ok:
+                        # Genuine MAC/key mismatch (possible MITM) — never report
+                        # success and never trust the device. Tell the other side we
+                        # are cancelling instead of sending m.key.verification.done.
+                        print(
+                            f"\n❌ VERIFICATION FAILED: {sas.cancel_reason or 'key mismatch'}"
+                        )
+                        try:
+                            await self.client.to_device(sas.get_cancellation())
+                        except Exception as e:
+                            self._debug(f"Could not send cancellation: {e}")
+                        self.cancelled = True
+                        return
+
+                    # MAC validated. Always send done — Element requires it even when
+                    # sas.verified is False due to the state-machine race noted above.
                     done_content = {"transaction_id": event.transaction_id}
                     done_msg = ToDeviceMessage(
                         type="m.key.verification.done",
@@ -258,12 +282,9 @@ class VerificationHandler:
 
                     self.verified = True
                     if sas.verified:
-                        # nio confirmed the SAS MACs match (Sas.verified is only True
-                        # once receive_mac_event has cryptographically validated every
-                        # key — any mismatch sets SasState.canceled). Only now is it
-                        # safe to persist trust in the local store; nio's Sas never
-                        # does this itself. Trusting when sas.verified is False would
-                        # bypass SAS verification, so we never do that.
+                        # nio confirmed the SAS MACs match. Only now is it safe to
+                        # persist trust in the local store; nio's Sas never does this
+                        # itself.
                         self.client.verify_device(sas.other_olm_device)
                         print("\n✅ VERIFICATION SUCCESSFUL!")
                     else:
@@ -283,6 +304,42 @@ class VerificationHandler:
                 self.cancelled = True
             else:
                 self._debug(f"Ignoring stale cancel for {event.transaction_id}")
+
+
+async def fetch_room_keys(client):
+    """Request room keys from now-verified devices and wait for them to arrive.
+
+    Runs after a successful verification so the freshly trusted device shares the
+    Megolm keys for encrypted rooms. Used by both the request and --listen flows.
+    """
+    print("\n📦 Fetching room keys from verified devices...")
+
+    rooms_checked = 0
+    for room_id, room in list(client.rooms.items())[:10]:
+        if room.encrypted:
+            rooms_checked += 1
+            try:
+                result = await client.room_messages(room_id, start="", limit=50)
+                if isinstance(result, RoomMessagesResponse):
+                    for event in result.chunk:
+                        if isinstance(event, MegolmEvent):
+                            try:
+                                await client.request_room_key(event)
+                            except Exception:
+                                pass
+            except Exception:
+                pass
+
+    print(f"   Checked {rooms_checked} encrypted rooms")
+    print("   Waiting for keys (30s)...")
+
+    for i in range(6):
+        await client.sync(timeout=5000)
+        if (i + 1) % 2 == 0:
+            print(f"   ... {(i + 1) * 5}s")
+
+    print("\n🎉 Device verified and keys synced!")
+    print("   Use matrix-fetch-keys.py ROOM for additional keys")
 
 
 async def run_verification(
@@ -373,7 +430,7 @@ async def run_verification(
                     return False
                 await client.sync(timeout=5000)
             if handler.verified:
-                print("\n🎉 Device verified!")
+                await fetch_room_keys(client)
             return handler.verified
 
         # Find target device if not specified
@@ -476,34 +533,7 @@ async def run_verification(
 
         # Post-verification: fetch room keys
         if handler.verified:
-            print("\n📦 Fetching room keys from verified devices...")
-
-            rooms_checked = 0
-            for room_id, room in list(client.rooms.items())[:10]:
-                if room.encrypted:
-                    rooms_checked += 1
-                    try:
-                        result = await client.room_messages(room_id, start="", limit=50)
-                        if isinstance(result, RoomMessagesResponse):
-                            for event in result.chunk:
-                                if isinstance(event, MegolmEvent):
-                                    try:
-                                        await client.request_room_key(event)
-                                    except Exception:
-                                        pass
-                    except Exception:
-                        pass
-
-            print(f"   Checked {rooms_checked} encrypted rooms")
-            print("   Waiting for keys (30s)...")
-
-            for i in range(6):
-                await client.sync(timeout=5000)
-                if (i + 1) % 2 == 0:
-                    print(f"   ... {(i + 1) * 5}s")
-
-            print("\n🎉 Device verified and keys synced!")
-            print("   Use matrix-fetch-keys.py ROOM for additional keys")
+            await fetch_room_keys(client)
 
         return handler.verified
 


### PR DESCRIPTION
Follow-up to #47 (already merged), addressing two issues found in review of that PR.

## 1. `matrix-e2ee-verify.py` reported verification success on a genuine MAC mismatch

nio's `Sas.receive_mac_event` **never raises** on a bad MAC — on a key mismatch (or invalid/unexpected MAC event) it silently sets the SAS state to `SasState.canceled` and returns (`crypto/sas.py`). The merged code caught only exceptions, so a genuine mismatch (a possible MITM) fell through to `self.verified = True`, sent `m.key.verification.done`, and printed `✅ VERIFICATION COMPLETE` / `🎉 Device verified and keys synced!`.

#47 correctly gated the *trust-persisting* `verify_device()` call on `sas.verified`, so a bad device was not trusted in the local store — but the script still **told the user it succeeded**, which is false assurance for a security-critical step.

This change distinguishes the benign state-machine race (`sas.verified` can be `False` even after a successful exchange) from a real failure using `sas.verified_devices` — a device id lands there only once its MAC has been cryptographically validated, and a later cancel does not clear it. On a real mismatch it now sends a cancellation (`sas.get_cancellation()`) and marks the attempt cancelled instead of claiming success.

## 2. `--listen` mode skipped the post-verification room-key fetch

The `--listen` branch returned immediately after verification, so it never ran the room-key fetch that the request path performs (the documented purpose: "complete verification and fetch room keys"). A user verifying via `--listen` saw `Device verified!` but had to run `matrix-fetch-keys.py` manually before encrypted history would decrypt.

The fetch is extracted into a shared `fetch_room_keys()` helper and now runs in both the request and `--listen` flows.

## Notes
- Verified the nio behavior against the installed `matrix-nio` source (`crypto/sas.py`: silent `canceled` on mismatch; `verified_devices` populated only on validated MAC; `get_cancellation()` available).
- `ruff check` and `ruff format --check` pass; `py_compile` clean.

## Test plan
- [ ] `matrix-e2ee-verify.py` with matching emojis → `VERIFICATION SUCCESSFUL`, device trusted, keys fetched.
- [ ] `matrix-e2ee-verify.py` with **mismatched** emojis (decline in Element) → `VERIFICATION FAILED`, no success message, device not trusted.
- [ ] `matrix-e2ee-verify.py --listen` → after Element-initiated verification, room keys are fetched (not just `Device verified!`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)