### PR TITLE
docs: gate E2EE device trust on verification + matrix-nio API notes

### DIFF
--- a/skills/matrix-communication/references/e2ee-guide.md
+++ b/skills/matrix-communication/references/e2ee-guide.md
@@ -125,7 +125,7 @@ The correct flow (as fixed in `matrix-e2ee-verify.py`):
 
 1. On a genuine mismatch (`not sas.verified and device not in sas.verified_devices`),
    send `m.key.verification.cancel`, report failure, and do **not** trust.
-2. Only on a confirmed match call `client.verify_device(sas.other_olm_device)` —
+2. Only when `sas.verified` is strictly `True`, call `client.verify_device(sas.other_olm_device)` —
    nio's `Sas` never persists trust itself.
 
 This bypass was caught by the automated commit security review (2026-06-27) and
@@ -141,7 +141,7 @@ version installed for this skill — `importlib.metadata.version("matrix-nio")`)
 |--------------------------|-----------------------------|
 | `nio.__version__` | Does **not** exist — accessing it raises `AttributeError`. Read the version from package metadata instead: `from importlib.metadata import version; version("matrix-nio")`. |
 | `from nio.store import DeviceStore` | Wrong path — raises `ImportError`. `DeviceStore` lives in `nio.crypto`: `from nio.crypto import DeviceStore`. |
-| `device.id` | Works — it is a read-only property aliasing `device_id` (returns `self.device_id`). It does **not** raise `AttributeError`; a claim that `device.id` errors is incorrect. |
+| `device.id` | Works — it is a read-only property aliasing `device_id` (returns `self.device_id`). It does **not** raise `AttributeError`, but always prefer the canonical `device_id` attribute for robustness against future library changes. |
 
 ## Reading E2EE Messages
 

--- a/skills/matrix-communication/references/e2ee-guide.md
+++ b/skills/matrix-communication/references/e2ee-guide.md
@@ -103,6 +103,46 @@ grep -q "VERIFICATION SUCCESSFUL" /tmp/verify_log.txt && echo "Verified!"
 - Enables automatic room key sharing from other devices
 - Required for some security-conscious rooms
 
+### Gate trust on the verification result — never trust unconditionally
+
+**Security rule:** only persist trust in a device *after* the SAS/emoji check
+has cryptographically passed. Calling `client.verify_device(...)` unconditionally
+marks the device trusted even on a MAC mismatch — that is a security bypass (a
+MITM device gets stored as trusted).
+
+What makes this subtle in matrix-nio:
+
+- `sas.receive_mac_event(...)` **never raises** on a bad MAC — it silently moves
+  the SAS to `SasState.canceled`. A bare `try/except` around it therefore catches
+  nothing and is not a safety check.
+- `sas.verified` can be `False` even after a *successful* MAC exchange, due to a
+  race in nio's state machine, so it cannot by itself distinguish a genuine
+  mismatch from the benign race. A device id appears in `sas.verified_devices`
+  only once its MAC is cryptographically validated, and a later cancel does not
+  clear it — so that set is the authoritative "MACs matched" signal.
+
+The correct flow (as fixed in `matrix-e2ee-verify.py`):
+
+1. On a genuine mismatch (`not sas.verified and device not in sas.verified_devices`),
+   send `m.key.verification.cancel`, report failure, and do **not** trust.
+2. Only on a confirmed match call `client.verify_device(sas.other_olm_device)` —
+   nio's `Sas` never persists trust itself.
+
+This bypass was caught by the automated commit security review (2026-06-27) and
+re-gated on `sas.verified` in
+[#48](https://github.com/netresearch/matrix-skill/pull/48).
+
+## matrix-nio API notes (0.25.2)
+
+Maintainer notes for the E2EE scripts. Verified against matrix-nio 0.25.2 (the
+version installed for this skill — `importlib.metadata.version("matrix-nio")`):
+
+| What you might reach for | Reality (matrix-nio 0.25.2) |
+|--------------------------|-----------------------------|
+| `nio.__version__` | Does **not** exist — accessing it raises `AttributeError`. Read the version from package metadata instead: `from importlib.metadata import version; version("matrix-nio")`. |
+| `from nio.store import DeviceStore` | Wrong path — raises `ImportError`. `DeviceStore` lives in `nio.crypto`: `from nio.crypto import DeviceStore`. |
+| `device.id` | Works — it is a read-only property aliasing `device_id` (returns `self.device_id`). It does **not** raise `AttributeError`; a claim that `device.id` errors is incorrect. |
+
 ## Reading E2EE Messages
 
 ```bash


### PR DESCRIPTION
From a cross-session retrospective (2026-06-27). Adds one learning to the E2EE guide (`skills/matrix-communication/references/e2ee-guide.md`) — references-only, no script behavior change.

## What changed

Two related items added to `references/e2ee-guide.md`:

1. **Gate device trust on the verification result.** Documents the security rule that `client.verify_device(...)` must be gated on the SAS/emoji outcome (`sas.verified` / `sas.verified_devices`) — an unconditional `verify_device` trusts a device even on a MAC mismatch (a MITM bypass). Captures the matrix-nio subtleties (`receive_mac_event` never raises on a bad MAC; `sas.verified` can be `False` after a successful exchange due to a state-machine race, so `verified_devices` is the authoritative signal). This bypass was caught by the automated commit security review and fixed in #48.

2. **matrix-nio API notes (0.25.2)** — maintainer notes verified against the installed nio 0.25.2:
   - `nio.__version__` does not exist (raises `AttributeError`) — use `importlib.metadata.version("matrix-nio")`.
   - `DeviceStore` is **not** importable from `nio.store` (`ImportError`); the real path is `from nio.crypto import DeviceStore`.
   - `device.id` is a read-only property aliasing `device_id` and does **not** raise — a reviewer claim that it errors is incorrect.

All three nio facts were re-verified against matrix-nio 0.25.2 in this environment before documenting.

## Version

No version bump — references-only change. The `check-version-parity` hook only triggers on `plugin.json` / `SKILL.md` / `composer.json`, none of which were touched (hook skipped cleanly in pre-commit).

## Validation

`pre-commit run --files` on the changed file: trailing-whitespace, end-of-file-fixer, markdownlint-cli2 all **Passed**; version-parity and other hooks correctly skipped (no relevant files).