### PR TITLE
chore(release): v1.25.3

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "matrix-communication",
-  "version": "1.25.2",
+  "version": "1.25.3",
   "description": "Agentic Skills for Matrix: client-side chat (matrix-communication), Synapse homeserver administration (matrix-administration), and structured announcement composition (matrix-announcement). Works with any Matrix/Synapse homeserver.",
   "author": {
     "name": "Netresearch DTT GmbH",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ For the canonical narrative version of each release (rewritten after CI publishe
 
 ## [Unreleased]
 
+## [1.25.3] - 2026-07-01
+
+### Documentation
+
+- matrix-communication, matrix-announcement: added a "no editorializing" rule for messages and announcements — state what changed, not how good it is ([#51](https://github.com/netresearch/matrix-skill/pull/51)).
+
+## [1.25.2] - 2026-06-27
+
+### Fixed
+
+- matrix-communication: E2EE own-device delivery and verification — don't report verification success on a MAC mismatch, and fetch room keys in `--listen` ([#47](https://github.com/netresearch/matrix-skill/pull/47), [#48](https://github.com/netresearch/matrix-skill/pull/48)).
+
+### Documentation
+
+- matrix-communication: gate E2EE device trust strictly on verification, with matrix-nio API notes ([#49](https://github.com/netresearch/matrix-skill/pull/49)).
+
 ## [1.25.1] - 2026-06-18
 
 ### Fixed

--- a/skills/matrix-administration/SKILL.md
+++ b/skills/matrix-administration/SKILL.md
@@ -5,7 +5,7 @@ license: "(MIT AND CC-BY-SA-4.0). See LICENSE-MIT and LICENSE-CC-BY-SA-4.0"
 compatibility: "python3 (stdlib only) + a Matrix access token belonging to a Synapse server-admin user. Optional: graphviz `dot` for SVG. Synapse 1.x with admin API enabled."
 metadata:
   author: Netresearch DTT GmbH
-  version: "1.25.2"
+  version: "1.25.3"
   repository: https://github.com/netresearch/matrix-skill
 allowed-tools: Bash(python3:*) Bash(uv:*) Bash(dot:*) Read Write
 ---

--- a/skills/matrix-announcement/SKILL.md
+++ b/skills/matrix-announcement/SKILL.md
@@ -5,7 +5,7 @@ license: "(MIT AND CC-BY-SA-4.0). See LICENSE-MIT and LICENSE-CC-BY-SA-4.0"
 compatibility: "Pairs with matrix-communication for sending. Optional: headless Chromium for rendering HTML cards to PNG."
 metadata:
   author: Netresearch DTT GmbH
-  version: "1.25.2"
+  version: "1.25.3"
   repository: https://github.com/netresearch/matrix-skill
 allowed-tools: Bash(chromium:*) Bash(curl:*) Bash(jq:*) Read Write
 ---

--- a/skills/matrix-communication/SKILL.md
+++ b/skills/matrix-communication/SKILL.md
@@ -5,7 +5,7 @@ license: "(MIT AND CC-BY-SA-4.0). See LICENSE-MIT and LICENSE-CC-BY-SA-4.0"
 compatibility: "Requires python3, uv. Matrix homeserver access."
 metadata:
   author: Netresearch DTT GmbH
-  version: "1.25.2"
+  version: "1.25.3"
   repository: https://github.com/netresearch/matrix-skill
 allowed-tools: Bash(python3:*) Bash(uv:*) Read Write
 ---


### PR DESCRIPTION
Patch release.

- No-editorializing rule for messages/announcements: a `## No editorializing` section plus `references/no-editorializing.md`. (#51)

Tag v1.25.3 after merge to publish.