### PR TITLE
chore(release): v1.25.4

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "matrix-communication",
-  "version": "1.25.3",
+  "version": "1.25.4",
   "description": "Agentic Skills for Matrix: client-side chat (matrix-communication), Synapse homeserver administration (matrix-administration), and structured announcement composition (matrix-announcement). Works with any Matrix/Synapse homeserver.",
   "author": {
     "name": "Netresearch DTT GmbH",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ For the canonical narrative version of each release (rewritten after CI publishe
 
 ## [Unreleased]
 
+## [1.25.4] - 2026-07-13
+
+### Fixed
+
+- matrix-announcement: resolve the cross-skill script path in SKILL.md ([#53](https://github.com/netresearch/matrix-skill/pull/53)).
+
+### Documentation
+
+- matrix-communication: `no-editorializing.md` now points at the canonical copy ([#54](https://github.com/netresearch/matrix-skill/pull/54)).
+- matrix-announcement: trimmed SKILL.md generic bloat to meet the 500-word cap ([#53](https://github.com/netresearch/matrix-skill/pull/53)).
+
 ## [1.25.3] - 2026-07-01
 
 ### Documentation

--- a/skills/matrix-administration/SKILL.md
+++ b/skills/matrix-administration/SKILL.md
@@ -5,7 +5,7 @@ license: "(MIT AND CC-BY-SA-4.0). See LICENSE-MIT and LICENSE-CC-BY-SA-4.0"
 compatibility: "python3 (stdlib only) + a Matrix access token belonging to a Synapse server-admin user. Optional: graphviz `dot` for SVG. Synapse 1.x with admin API enabled."
 metadata:
   author: Netresearch DTT GmbH
-  version: "1.25.3"
+  version: "1.25.4"
   repository: https://github.com/netresearch/matrix-skill
 allowed-tools: Bash(python3:*) Bash(uv:*) Bash(dot:*) Read Write
 ---

--- a/skills/matrix-announcement/SKILL.md
+++ b/skills/matrix-announcement/SKILL.md
@@ -5,7 +5,7 @@ license: "(MIT AND CC-BY-SA-4.0). See LICENSE-MIT and LICENSE-CC-BY-SA-4.0"
 compatibility: "Pairs with matrix-communication for sending. Optional: Chromium for HTML-card rendering."
 metadata:
   author: Netresearch DTT GmbH
-  version: "1.25.3"
+  version: "1.25.4"
   repository: https://github.com/netresearch/matrix-skill
 allowed-tools: Bash(chromium:*) Bash(curl:*) Bash(jq:*) Read Write
 ---

--- a/skills/matrix-communication/SKILL.md
+++ b/skills/matrix-communication/SKILL.md
@@ -5,7 +5,7 @@ license: "(MIT AND CC-BY-SA-4.0). See LICENSE-MIT and LICENSE-CC-BY-SA-4.0"
 compatibility: "Requires python3, uv. Matrix homeserver access."
 metadata:
   author: Netresearch DTT GmbH
-  version: "1.25.3"
+  version: "1.25.4"
   repository: https://github.com/netresearch/matrix-skill
 allowed-tools: Bash(python3:*) Bash(uv:*) Read Write
 ---


### PR DESCRIPTION
Release v1.25.4.

Changes since v1.25.3:

- matrix-communication: no-editorializing.md points at the canonical copy (#54)
- matrix-announcement: SKILL.md trimmed to the 500-word cap; cross-skill script path resolved (#53)
- Version bump: plugin.json + all three SKILL.md frontmatter to 1.25.4; CHANGELOG entry added