### PR TITLE
feat(matrix-announcement): add Findings type tag and findings-report structure rules

### DIFF
--- a/skills/matrix-announcement/SKILL.md
+++ b/skills/matrix-announcement/SKILL.md
@@ -33,7 +33,7 @@ Content rules for Matrix announcements: HTML subset, type tags, glyphs, `m.text`
 - `Findings` — result of an investigation or audit
 - `RFC` — proposal seeking feedback
 
-Findings reports group by category of finding (`Errors found`, `No error, expected behaviour`), never by who was wrong (`Real errors`, `Corrections`).
+Findings reports group by category of finding (`Errors found`, `No error, expected behavior`), never by who was wrong (`Real errors`, `Corrections`).
 
 ## Glyphs
 

--- a/skills/matrix-announcement/SKILL.md
+++ b/skills/matrix-announcement/SKILL.md
@@ -18,7 +18,7 @@ Content rules for Matrix announcements: HTML subset, type tags, glyphs, `m.text`
 
 1. **One headline, one purpose.**
 2. **`formatted_body` in the HTML subset, not Markdown.** `body` is the plaintext fallback — clients aren't required to parse Markdown.
-3. **Lists beat paragraphs.**
+3. **Lists beat paragraphs.** Enumerable items — findings, projects, failures, tickets — are a `<ul>`, however long each item runs. A paragraph opening with a bold word is emphasis, not structure.
 4. **Wrap code.** Commands, paths, versions, IDs, env vars in `<code>`; multi-line in `<pre><code class="language-…">`.
 5. **Layout > words → render an HTML card to PNG.** Comparisons, dashboards, multi-row tables die in `formatted_body`.
 
@@ -30,11 +30,14 @@ Content rules for Matrix announcements: HTML subset, type tags, glyphs, `m.text`
 - `Digest` — weekly / multi-skill roundup
 - `Heads-up` — breaking change, deprecation
 - `Postmortem` — incident summary
+- `Findings` — result of an investigation or audit
 - `RFC` — proposal seeking feedback
+
+Findings reports group by category of finding (`Errors found`, `No error, expected behaviour`), never by who was wrong (`Real errors`, `Corrections`).
 
 ## Glyphs
 
-One leading glyph at most. **Never** trailing decoration, multi-emoji ladders, 🚀, or 🎉. Approved: 🤖 bot · 📦 release · 🔧 tooling · 🛡 security · ⚠️ heads-up · 📋 digest · 🔬 RFC · 🚑 hotfix · 🔥 postmortem · ✨ new capability (sparingly).
+One leading glyph at most. **Never** trailing decoration, multi-emoji ladders, 🚀, or 🎉. Approved: 🤖 bot · 📦 release · 🔧 tooling · 🛡 security · ⚠️ heads-up · 📋 digest · 🔬 RFC · 🚑 hotfix · 🔥 postmortem · 🔎 findings · ✨ new capability (sparingly).
 
 ## Pre-send checklist
 
@@ -42,6 +45,8 @@ One leading glyph at most. **Never** trailing decoration, multi-emoji ladders, �
 - [ ] Opens with the change, not "we're excited to".
 - [ ] URLs wrapped in `<a>`, destination as text.
 - [ ] Every entity is a link: issue keys (even mid-sentence), versions → release page, MRs/PRs (`project/path!N` / `org/repo#N`), pipelines, commits. Status updates: one item per line, linked key first, blank lines between.
+- [ ] Enumerable items in a `<ul>`, not bold-led paragraphs (rule 3).
+- [ ] Findings headings name the category, not the person.
 - [ ] Code wrapped (rule 4).
 - [ ] Glyph OK (rules above).
 - [ ] `body` reads standalone, not stripped HTML.

--- a/skills/matrix-announcement/evals/evals.json
+++ b/skills/matrix-announcement/evals/evals.json
@@ -167,10 +167,10 @@
       "id": 14,
       "eval_name": "findings-headings-name-category",
       "prompt": "A colleague claimed updates were missing for three projects. Two of the three are genuine failures; the third worked and automerged, so their assumption was wrong. Write the section headings for this report.",
-      "expected_output": "Headings name the category of finding, e.g. 'Errors found' and 'No error, expected behaviour'.",
+      "expected_output": "Headings name the category of finding, e.g. 'Errors found' and 'No error, expected behavior'.",
       "files": [],
       "assertions": [
-        "Headings describe the system behaviour, not the person's mistake",
+        "Headings describe the system behavior, not the person's mistake",
         "Does NOT use 'Real errors', 'Corrections', 'Wrong assumptions' or equivalents that grade the reader",
         "Working-as-designed results get their own section rather than being framed as rebuttals"
       ]

--- a/skills/matrix-announcement/evals/evals.json
+++ b/skills/matrix-announcement/evals/evals.json
@@ -149,6 +149,31 @@
         "Does NOT use <h1> or <h2>",
         "First-level title remains the type-tag line, not a heading"
       ]
+    },
+    {
+      "id": 13,
+      "eval_name": "long-findings-still-a-list",
+      "prompt": "Report the result of checking an automated Renovate run across projects. Three findings need explaining: vemags (ticket job fails because a Jira user cannot be assigned, so no ticket and no automerge), bmdv (a grep -F without -x filters the repo out via substring match), hsm (code lives in a foreign Forgejo, unreachable). Each finding needs two to three sentences.",
+      "expected_output": "Renders the three findings as a <ul> with one <li> each, despite each item running several sentences.",
+      "files": [],
+      "assertions": [
+        "Uses <ul> with one <li> per finding",
+        "Does NOT render findings as consecutive paragraphs that merely begin with a bold subject",
+        "Long items stay a single <li> rather than being split into paragraphs",
+        "Each <li> opens with the linked or bolded subject (vemags / bmdv / hsm)"
+      ]
+    },
+    {
+      "id": 14,
+      "eval_name": "findings-headings-name-category",
+      "prompt": "A colleague claimed updates were missing for three projects. Two of the three are genuine failures; the third worked and automerged, so their assumption was wrong. Write the section headings for this report.",
+      "expected_output": "Headings name the category of finding, e.g. 'Errors found' and 'No error, expected behaviour'.",
+      "files": [],
+      "assertions": [
+        "Headings describe the system behaviour, not the person's mistake",
+        "Does NOT use 'Real errors', 'Corrections', 'Wrong assumptions' or equivalents that grade the reader",
+        "Working-as-designed results get their own section rather than being framed as rebuttals"
+      ]
     }
   ]
 }

--- a/skills/matrix-announcement/references/anti-patterns.md
+++ b/skills/matrix-announcement/references/anti-patterns.md
@@ -83,7 +83,7 @@ around the person turn a finding into a verdict.
 
 ```
 **Errors found**
-**No error, expected behaviour**
+**No error, expected behavior**
 ```
 
 Name what the *system* did, not whose assumption failed. The facts underneath are

--- a/skills/matrix-announcement/references/anti-patterns.md
+++ b/skills/matrix-announcement/references/anti-patterns.md
@@ -28,6 +28,69 @@ What it blocks:
 Install: /install-plugin https://github.com/netresearch/github-release-skill
 ```
 
+## ✗ Bold lead-in paragraphs
+
+The wall of text above is easy to spot — it is marketing prose. This one is not: the
+content is factual, linked, and correctly sectioned, so it reads as "already structured"
+while writing. It still lands as a wall, because each finding is a paragraph that merely
+*starts* with a bold word.
+
+```
+**Errors found**
+
+**vemags** — MR !49 exists, but typo3:create-ticket fails: User 'x' cannot be
+assigned issues. The script aborts via set -eu, so neither ticket nor automerge
+happens. vemags stays on 13.4.32.
+
+**bmdv** — bmdv/cms/main-13 is never picked up by the cron. In
+generate-child-pipelines.sh:79 grep -v -F -f matches substrings without -x, so the
+slow-repos.txt entry bmdv/cms/main swallows bmdv/cms/main-13 — no log entry.
+```
+
+### ✓ One finding, one list item
+
+```html
+<strong>Errors found</strong>
+<ul>
+  <li><strong>vemags</strong> — <a href="…/merge_requests/49">vemags/cms/main!49</a>
+      exists, but <code>typo3:create-ticket</code> fails:
+      <code>User 'x' cannot be assigned issues.</code> The script aborts via
+      <code>set -eu</code>, so neither ticket nor automerge happens.</li>
+  <li><strong>bmdv</strong> — <code>bmdv/cms/main-13</code> is never picked up by the
+      cron. <a href="…#L79"><code>generate-child-pipelines.sh:79</code></a> uses
+      <code>grep -v -F -f</code> without <code>-x</code>, so the
+      <code>slow-repos.txt</code> entry <code>bmdv/cms/main</code> swallows
+      <code>bmdv/cms/main-13</code>.</li>
+</ul>
+```
+
+**The test:** if the items are enumerable — findings, projects, tickets, failures — they
+are a `<ul>`, no matter how long each item is. Length is not a reason to drop the list;
+it is the reason you need one. A bold word at the start of a paragraph is emphasis, not
+structure: it gives the reader no left edge to scan down.
+
+## ✗ Headings that name who was wrong
+
+Reports that refute someone's assumptions get read by that someone. Headings framed
+around the person turn a finding into a verdict.
+
+```
+**Real errors**          ← implies the reader's other points were fake
+**Corrections**          ← "I am correcting you"
+```
+
+### ✓ Headings that name the category
+
+```
+**Errors found**
+**No error, expected behaviour**
+```
+
+Name what the *system* did, not whose assumption failed. The facts underneath are
+identical; only the framing changes, and the framing decides whether the facts get read.
+Related but distinct from [no-editorializing](../../matrix-communication/references/no-editorializing.md):
+that rule bans praising your own work, this one bans grading someone else's.
+
 ## ✗ Emoji ladder
 
 ```

--- a/skills/matrix-announcement/references/glyphs.md
+++ b/skills/matrix-announcement/references/glyphs.md
@@ -17,6 +17,7 @@ The rule: **one glyph at the front of the title**, optionally one inline glyph p
 | 🔬 | RFC | proposal, request for comment |
 | 🚑 | hotfix | urgent patch |
 | 🔥 | postmortem | incident summary |
+| 🔎 | findings | investigation or audit result |
 | ✨ | new capability | use sparingly; never on every release |
 
 ## Banned

--- a/skills/matrix-announcement/references/structure.md
+++ b/skills/matrix-announcement/references/structure.md
@@ -30,7 +30,10 @@ Pick one. Do not stack.
 | `Digest` | weekly / multi-skill roundup | `Digest: skill ecosystem — week of 2026-04-22` |
 | `Heads-up` | breaking change, deprecation, migration | `Heads-up: matrix-skill v2 drops Python 3.8` |
 | `Postmortem` | incident summary | `Postmortem: CI cache wipe 2026-04-25` |
+| `Findings` | result of an investigation or audit — what ran, what broke, what is expected behaviour | `Findings: Renovate run after TYPO3 14.3.5` |
 | `RFC` | proposal looking for feedback | `RFC: unified checkpoint schema` |
+
+`Postmortem` vs `Findings`: a postmortem explains one incident that is already over (symptom → cause → fix). `Findings` reports what a check turned up across several subjects, where some results are failures and some are working-as-designed.
 
 ## Section headings
 
@@ -40,6 +43,7 @@ Use **at most three** sections per message. Common patterns:
 - **New / Changed / Fixed** — for version bumps
 - **Highlights / This week's releases / Open questions** — for digests
 - **Symptom / Cause / Fix** — for postmortems
+- **Errors found / No error, expected behaviour / Next steps** — for findings reports
 - **Why / How / Try it** — for proposals
 
 Render headings as `<strong>Heading:</strong>` on its own line, or `<h3>` if the message is long enough to warrant TOC-style skimming. Avoid `<h2>`/`<h1>` (too loud).
@@ -87,6 +91,12 @@ Readers click the thing they are looking at — every linkable entity in the mes
 ### Status updates: one item per line
 
 Multi-item progress posts (maintenance logs, digest-style updates) get one line per ticket/work item, separated by blank lines, each line starting with the linked issue key. Readers scan for *their* item; interleaved prose hides it.
+
+### Findings reports: one finding, one list item
+
+A findings report (investigation result, audit, "did the automation run?") is a list, not prose — `<ul>` with one `<li>` per finding, each opening with the linked subject. This holds when the items are long: a finding that needs three sentences is still one `<li>`. A paragraph that merely starts with a bold word gives the reader no left edge to scan down. See [anti-patterns](anti-patterns.md) ("Bold lead-in paragraphs").
+
+Group findings under headings that name **the category of finding, never the person who was wrong**: `Errors found` / `No error, expected behaviour`, not `Real errors` / `Corrections`. Reports that refute someone's assumptions are read by that someone, and the framing decides whether the facts get read at all.
 
 ## Length budget
 

--- a/skills/matrix-announcement/references/structure.md
+++ b/skills/matrix-announcement/references/structure.md
@@ -30,7 +30,7 @@ Pick one. Do not stack.
 | `Digest` | weekly / multi-skill roundup | `Digest: skill ecosystem — week of 2026-04-22` |
 | `Heads-up` | breaking change, deprecation, migration | `Heads-up: matrix-skill v2 drops Python 3.8` |
 | `Postmortem` | incident summary | `Postmortem: CI cache wipe 2026-04-25` |
-| `Findings` | result of an investigation or audit — what ran, what broke, what is expected behaviour | `Findings: Renovate run after TYPO3 14.3.5` |
+| `Findings` | result of an investigation or audit — what ran, what broke, what is expected behavior | `Findings: Renovate run after TYPO3 14.3.5` |
 | `RFC` | proposal looking for feedback | `RFC: unified checkpoint schema` |
 
 `Postmortem` vs `Findings`: a postmortem explains one incident that is already over (symptom → cause → fix). `Findings` reports what a check turned up across several subjects, where some results are failures and some are working-as-designed.
@@ -43,7 +43,7 @@ Use **at most three** sections per message. Common patterns:
 - **New / Changed / Fixed** — for version bumps
 - **Highlights / This week's releases / Open questions** — for digests
 - **Symptom / Cause / Fix** — for postmortems
-- **Errors found / No error, expected behaviour / Next steps** — for findings reports
+- **Errors found / No error, expected behavior / Next steps** — for findings reports
 - **Why / How / Try it** — for proposals
 
 Render headings as `<strong>Heading:</strong>` on its own line, or `<h3>` if the message is long enough to warrant TOC-style skimming. Avoid `<h2>`/`<h1>` (too loud).
@@ -96,7 +96,7 @@ Multi-item progress posts (maintenance logs, digest-style updates) get one line 
 
 A findings report (investigation result, audit, "did the automation run?") is a list, not prose — `<ul>` with one `<li>` per finding, each opening with the linked subject. This holds when the items are long: a finding that needs three sentences is still one `<li>`. A paragraph that merely starts with a bold word gives the reader no left edge to scan down. See [anti-patterns](anti-patterns.md) ("Bold lead-in paragraphs").
 
-Group findings under headings that name **the category of finding, never the person who was wrong**: `Errors found` / `No error, expected behaviour`, not `Real errors` / `Corrections`. Reports that refute someone's assumptions are read by that someone, and the framing decides whether the facts get read at all.
+Group findings under headings that name **the category of finding, never the person who was wrong**: `Errors found` / `No error, expected behavior`, not `Real errors` / `Corrections`. Reports that refute someone's assumptions are read by that someone, and the framing decides whether the facts get read at all.
 
 ## Length budget
 

--- a/skills/matrix-announcement/references/text-templates.md
+++ b/skills/matrix-announcement/references/text-templates.md
@@ -113,18 +113,18 @@ Headings name the category of finding, never who was wrong. One `<li>` per findi
 <p>🔎 <strong>Findings:</strong> {what was checked}</p>
 <p>{one-sentence verdict: what ran, how much of it worked}.</p>
 
-<p><strong>Errors found</strong></p>
+<p><strong>Errors found:</strong></p>
 <ul>
   <li><strong>{subject}</strong> — {what fails}: <code>{error}</code>. {consequence}.</li>
   <li><strong>{subject}</strong> — {what fails}. {cause, with a link to the line}.</li>
 </ul>
 
-<p><strong>No error, expected behaviour</strong></p>
+<p><strong>No error, expected behavior:</strong></p>
 <ul>
   <li><strong>{subject}</strong> — {why it looked broken but is not}.</li>
 </ul>
 
-<p><strong>Next steps</strong></p>
+<p><strong>Next steps:</strong></p>
 <ul>
   <li>{action}, tracked in <a href="{ticket}">{ticket-id}</a>.</li>
 </ul>

--- a/skills/matrix-announcement/references/text-templates.md
+++ b/skills/matrix-announcement/references/text-templates.md
@@ -105,6 +105,31 @@ For more than ~6 lines of releases, render `templates/weekly-digest.html` to PNG
 <p><strong>Follow-up:</strong> <a href="{ticket}">{ticket-id}</a></p>
 ```
 
+## Findings (investigation / audit result)
+
+Headings name the category of finding, never who was wrong. One `<li>` per finding, however long the item runs.
+
+```html
+<p>🔎 <strong>Findings:</strong> {what was checked}</p>
+<p>{one-sentence verdict: what ran, how much of it worked}.</p>
+
+<p><strong>Errors found</strong></p>
+<ul>
+  <li><strong>{subject}</strong> — {what fails}: <code>{error}</code>. {consequence}.</li>
+  <li><strong>{subject}</strong> — {what fails}. {cause, with a link to the line}.</li>
+</ul>
+
+<p><strong>No error, expected behaviour</strong></p>
+<ul>
+  <li><strong>{subject}</strong> — {why it looked broken but is not}.</li>
+</ul>
+
+<p><strong>Next steps</strong></p>
+<ul>
+  <li>{action}, tracked in <a href="{ticket}">{ticket-id}</a>.</li>
+</ul>
+```
+
 ## RFC
 
 ```html


### PR DESCRIPTION
## Context

Came out of a retro on a real room post: a Renovate/TYPO3 findings report in `#typo3:netresearch.de`. The post was factually correct, fully linked and sectioned — and the reviewer still had to restyle it by hand in three edits.

## What the reviewer changed

| Posted | Corrected to |
|---|---|
| `**vemags** — …` as a paragraph per finding | `- **vemags** — …` as a list item |
| `Echte Fehler` ("real errors") / `Korrekturen` ("corrections") | `Aufgetretene Fehler` ("errors found") / `Keine Fehler, erwartetes Verhalten` ("no error, expected behaviour") |

## Why the skill did not prevent it

Rule 3 already says *"Lists beat paragraphs"*, and eval #2 `lists-not-prose` already exists. Both were read and neither fired:

- The `Wall of text` anti-pattern only demonstrates **marketing prose** ("We're excited to announce…"). A factual, linked, sectioned report reads as *already structured* while writing, so the author self-exempts.
- Eval #2 only covers **four short release bullets**. It never establishes that a finding needing three sentences is still one `<li>`.
- `Status updates: one item per line` in `structure.md` prescribes blank-line-separated lines — close enough to the wrong shape to feel compliant.

The heading problem had no coverage at all. `Real errors` / `Corrections` frames a report as *grading the reader*; the facts underneath were identical, only the framing changed.

## Changes

- **`SKILL.md`** — rule 3 spells out that enumerable items are a `<ul>` however long each item runs, and that a bold-led paragraph is emphasis, not structure. New `Findings` tag + `🔎` glyph + two checklist items.
- **`references/anti-patterns.md`** — two new anti-patterns with before/after taken from the actual post: *Bold lead-in paragraphs* and *Headings that name who was wrong*.
- **`references/structure.md`** — `Findings` tag, an explicit `Postmortem` vs `Findings` boundary, section-heading pattern, and the findings-report rule.
- **`references/glyphs.md`, `references/text-templates.md`** — glyph and a ready template for the new tag.
- **`evals/evals.json`** — #13 `long-findings-still-a-list` (reproduces the exact failure: three multi-sentence findings), #14 `findings-headings-name-category`.

`Findings` is scoped against `Postmortem`: a postmortem explains one finished incident (symptom → cause → fix); `Findings` reports what a check turned up across several subjects, where some results are failures and some are working-as-designed.

## Verification

- `markdownlint-cli2` over `skills/matrix-announcement/**/*.md` — 0 errors
- `scripts/verify-harness.sh --status` — Level 3, 18/18
- `evals.json` parses; diff is additive only (0 deletions), existing entries untouched
- All relative links in the touched files resolve, including the cross-skill link to `matrix-communication/references/no-editorializing.md`

## Note for review

The two new anti-patterns are deliberately framed as *"the content was fine, the shape was not"* — that is the distinction the existing wall-of-text example fails to make, and the reason the rule got skipped.