### PR TITLE
feat(matrix-communication): add room creation, invite, and power-level scripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ For the canonical narrative version of each release (rewritten after CI publishe
 
 ## [Unreleased]
 
+### Added
+
+- matrix-communication: room management — `matrix-create-room.py` (create, with optional alias/topic/initial invites), `matrix-invite.py`, and `matrix-power-level.py` (`--show`/`--get`/`--set`, GET-modify-PUT against `m.room.power_levels`).
+
 ## [1.25.4] - 2026-07-13
 
 ### Fixed

--- a/skills/matrix-communication/README.md
+++ b/skills/matrix-communication/README.md
@@ -10,6 +10,7 @@ Send and receive messages in Matrix chat rooms with full E2EE encryption support
 - **Edit Messages** - Modify existing messages
 - **Reactions** - Add emoji reactions (✅ 👍 🚀)
 - **Redact** - Delete messages
+- **Room Management** - Create rooms, invite users, manage power levels
 - **Bot Prefix** - Optional 🤖 prefix for automated messages
 
 ## Installation

--- a/skills/matrix-communication/SKILL.md
+++ b/skills/matrix-communication/SKILL.md
@@ -46,6 +46,12 @@ uv run ${CLAUDE_SKILL_DIR}/scripts/matrix-rooms.py
 uv run ${CLAUDE_SKILL_DIR}/scripts/matrix-rooms.py --search ops
 uv run ${CLAUDE_SKILL_DIR}/scripts/matrix-resolve.py "#room:server"
 
+# Room management (create, invite, promote)
+uv run ${CLAUDE_SKILL_DIR}/scripts/matrix-create-room.py "Room Name" --alias localpart --invite '@user:server'
+uv run ${CLAUDE_SKILL_DIR}/scripts/matrix-invite.py ROOM '@user:server'
+uv run ${CLAUDE_SKILL_DIR}/scripts/matrix-power-level.py ROOM --show
+uv run ${CLAUDE_SKILL_DIR}/scripts/matrix-power-level.py ROOM --set '@user:server' 50
+
 # E2EE management
 uv run ${CLAUDE_SKILL_DIR}/scripts/matrix-e2ee-setup.py --status
 MATRIX_PASSWORD="pass" uv run ${CLAUDE_SKILL_DIR}/scripts/matrix-e2ee-setup.py
@@ -68,7 +74,9 @@ python3 ${CLAUDE_SKILL_DIR}/scripts/matrix-doctor.py --install
 | React | `matrix-react.py` | (same) |
 | Delete | `matrix-redact.py` | (same) |
 
-Other: `matrix-rooms.py`, `matrix-resolve.py`, `matrix-e2ee-setup.py`, `matrix-e2ee-verify.py`, `matrix-fetch-keys.py`, `matrix-key-backup.py`, `matrix-doctor.py`.
+Other: `matrix-rooms.py`, `matrix-resolve.py`, `matrix-create-room.py`, `matrix-invite.py`, `matrix-power-level.py`, `matrix-e2ee-setup.py`, `matrix-e2ee-verify.py`, `matrix-fetch-keys.py`, `matrix-key-backup.py`, `matrix-doctor.py`.
+
+`matrix-power-level.py --set`: `--show` first on rooms you didn't create (see `references/api-reference.md`).
 
 ## Config
 

--- a/skills/matrix-communication/evals/evals.json
+++ b/skills/matrix-communication/evals/evals.json
@@ -305,6 +305,43 @@
         "Suggests matrix-key-backup.py with --recovery-key and --import-keys, or matrix-fetch-keys.py",
         "Does not suggest non-E2EE fallback as primary solution"
       ]
+    },
+    {
+      "id": 26,
+      "eval_name": "create-room",
+      "prompt": "Create a new private Matrix room called 'LSB Project' with the alias 'lsb' and invite @jane.doe:netresearch.de.",
+      "expected_output": "Uses matrix-create-room.py with name, --alias, and --invite.",
+      "files": [],
+      "assertions": [
+        "Uses matrix-create-room.py script",
+        "Passes 'LSB Project' as the room name",
+        "Uses --alias lsb",
+        "Uses --invite '@jane.doe:netresearch.de'"
+      ]
+    },
+    {
+      "id": 27,
+      "eval_name": "invite-to-room",
+      "prompt": "Invite @jane.doe:netresearch.de to the ops room.",
+      "expected_output": "Uses matrix-invite.py with room identifier and user ID.",
+      "files": [],
+      "assertions": [
+        "Uses matrix-invite.py script",
+        "Passes 'ops' as room identifier",
+        "Passes '@jane.doe:netresearch.de' as user ID"
+      ]
+    },
+    {
+      "id": 28,
+      "eval_name": "promote-to-moderator",
+      "prompt": "Promote @jane.doe:netresearch.de to moderator in the LSB Project room.",
+      "expected_output": "Uses matrix-power-level.py --set with the user ID and level 50, ideally after checking the room with --show first.",
+      "files": [],
+      "assertions": [
+        "Uses matrix-power-level.py script",
+        "Uses --set '@jane.doe:netresearch.de' 50",
+        "Does not attempt a raw PUT that would drop other power_levels keys"
+      ]
     }
   ]
 }

--- a/skills/matrix-communication/references/api-reference.md
+++ b/skills/matrix-communication/references/api-reference.md
@@ -61,6 +61,64 @@ GET /rooms/{roomId}/state/m.room.name
 }
 ```
 
+### Room Management
+
+```bash
+# Create a room
+POST /createRoom
+
+# Body:
+{
+  "name": "Room Name",
+  "preset": "private_chat",
+  "room_alias_name": "localpart",
+  "topic": "Optional topic",
+  "invite": ["@user:server"]
+}
+
+# preset: private_chat (default) | public_chat | trusted_private_chat
+
+# Response:
+{
+  "room_id": "!abc:server"
+}
+
+# Invite a user
+POST /rooms/{roomId}/invite
+
+# Body:
+{
+  "user_id": "@user:server"
+}
+
+# Response: {} on success
+
+# Get power levels (state key is the empty string, hence the trailing slash)
+GET /rooms/{roomId}/state/m.room.power_levels/
+
+# Response (abridged):
+{
+  "users": {"@admin:server": 100},
+  "users_default": 0,
+  "events": {...},
+  "state_default": 50,
+  "ban": 50, "kick": 50, "redact": 50, "invite": 0
+}
+
+# Set power levels — PUT replaces the ENTIRE state event, no server-side
+# merge. Always GET first, mutate the "users" dict, then PUT the whole
+# object back, or every other key (state_default, ban/kick/redact/invite,
+# other users' levels) gets wiped.
+PUT /rooms/{roomId}/state/m.room.power_levels/
+
+# The acting user's own power level must be >= the level being granted
+# and >= the target's current level, or the homeserver returns M_FORBIDDEN.
+
+# On newer room versions the creator has implicit, permanent authority and
+# must NOT appear in "users" — setting the creator's own level is rejected:
+# {"error": "Creator user must not appear in content.users", ...}
+```
+
 ### Messages
 
 ```bash

--- a/skills/matrix-communication/scripts/_lib/__init__.py
+++ b/skills/matrix-communication/scripts/_lib/__init__.py
@@ -44,6 +44,7 @@ from _lib.rooms import (
     get_room_info,
     list_joined_rooms,
     resolve_room_alias,
+    resolve_room_cli,
 )
 
 # Utilities
@@ -79,6 +80,7 @@ __all__ = [
     "prefer_ipv4",
     # Rooms
     "resolve_room_alias",
+    "resolve_room_cli",
     "save_credentials",
     # Formatting
     "shorten_service_urls",

--- a/skills/matrix-communication/scripts/_lib/rooms.py
+++ b/skills/matrix-communication/scripts/_lib/rooms.py
@@ -3,6 +3,8 @@
 All functions use ONLY stdlib.
 """
 
+import json
+import sys
 import urllib.parse
 
 from _lib.http import matrix_request
@@ -197,3 +199,53 @@ def find_room_in_nio_client(client_rooms: dict, search_term: str) -> str | None:
         return partial_matches[0]
 
     return None
+
+
+def resolve_room_cli(
+    config: dict, room_input: str, json_out: bool = False, debug: bool = False
+) -> str:
+    """Resolve a ROOM CLI argument (ID, alias, or name) to a room ID.
+
+    Shared by scripts that take a ROOM positional argument, so each script
+    doesn't reimplement the same ID/alias/name resolution order and error
+    formatting. Prints a JSON or human-readable error and exits 1 if the
+    room cannot be resolved — callers can assume a valid room ID is
+    returned or the process has already ended.
+    """
+    if room_input.startswith("!"):
+        if debug:
+            print(f"Using room ID directly: {room_input}", file=sys.stderr)
+        return room_input
+
+    if room_input.startswith("#"):
+        try:
+            room_id = resolve_room_alias(config, room_input)
+            if debug:
+                print(f"Resolved alias {room_input} -> {room_id}", file=sys.stderr)
+            return room_id
+        except ValueError as e:
+            if json_out:
+                print(json.dumps({"error": str(e)}))
+            else:
+                print(f"Error: {e}", file=sys.stderr)
+            sys.exit(1)
+
+    found_id, matches = find_room_by_name(config, room_input)
+    if found_id:
+        if debug:
+            print(f"Found room: {found_id}", file=sys.stderr)
+        return found_id
+
+    error_msg = f"Could not find room '{room_input}'"
+    if matches:
+        error_msg += ". Multiple matches found:\n"
+        for m in matches:
+            alias_str = f" ({m['alias']})" if m.get("alias") else ""
+            error_msg += f"  - {m['name']}{alias_str}: {m['room_id']}\n"
+    else:
+        error_msg += ". Use 'matrix-rooms.py' to list available rooms."
+    if json_out:
+        print(json.dumps({"error": error_msg}))
+    else:
+        print(f"Error: {error_msg}", file=sys.stderr)
+    sys.exit(1)

--- a/skills/matrix-communication/scripts/matrix-create-room.py
+++ b/skills/matrix-communication/scripts/matrix-create-room.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.10"
+# dependencies = []
+# ///
+"""Create a new Matrix room.
+
+Usage:
+    matrix-create-room.py NAME [OPTIONS]
+    matrix-create-room.py --help
+
+Arguments:
+    NAME        Room display name
+
+Options:
+    --alias LOCALPART   Room alias localpart, e.g. "lsb" -> #lsb:server
+                        (fails if the alias is already taken)
+    --topic TOPIC       Room topic
+    --invite USER_ID    Invite a user on creation (repeatable)
+    --preset PRESET     private_chat (default) | public_chat | trusted_private_chat
+    --json              Output as JSON
+    --quiet             Minimal output (just the room ID)
+    --debug             Show debug information
+
+Examples:
+    # Minimal private room
+    matrix-create-room.py "LSB Project"
+
+    # With alias and initial invites
+    matrix-create-room.py "LSB Project" --alias lsb \\
+        --invite '@tobias.hein:netresearch.de' --invite '@jane.doe:netresearch.de'
+
+    # Public room with topic
+    matrix-create-room.py "LSB Project" --topic "Landessportbund onboarding" \\
+        --preset public_chat
+"""
+
+import json
+import os
+import sys
+
+# Add script directory to path for _lib imports
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from _lib import load_config, matrix_request
+
+sys.stdout.reconfigure(line_buffering=True)
+sys.stderr.reconfigure(line_buffering=True)
+
+
+def create_room(
+    config: dict,
+    name: str,
+    alias: str | None = None,
+    topic: str | None = None,
+    invite: list[str] | None = None,
+    preset: str = "private_chat",
+) -> dict:
+    """Create a Matrix room.
+
+    Args:
+        config: Matrix config with homeserver and access_token
+        name: Room display name
+        alias: Room alias localpart (without # or :server)
+        topic: Room topic
+        invite: List of user IDs to invite on creation
+        preset: Room preset (private_chat, public_chat, trusted_private_chat)
+
+    Returns:
+        Response dict with 'room_id' on success, or 'error' on failure
+    """
+    content = {"name": name, "preset": preset}
+    if alias:
+        content["room_alias_name"] = alias
+    if topic:
+        content["topic"] = topic
+    if invite:
+        content["invite"] = invite
+
+    return matrix_request(config, "POST", "/createRoom", content)
+
+
+def main():
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Create a new Matrix room")
+    parser.add_argument("name", help="Room display name")
+    parser.add_argument(
+        "--alias", metavar="LOCALPART", help="Room alias localpart (e.g. 'lsb')"
+    )
+    parser.add_argument("--topic", help="Room topic")
+    parser.add_argument(
+        "--invite",
+        metavar="USER_ID",
+        action="append",
+        help="Invite a user on creation (repeatable)",
+    )
+    parser.add_argument(
+        "--preset",
+        choices=["private_chat", "public_chat", "trusted_private_chat"],
+        default="private_chat",
+        help="Room preset (default: private_chat)",
+    )
+    parser.add_argument("--json", action="store_true", help="Output as JSON")
+    parser.add_argument("--quiet", "-q", action="store_true", help="Minimal output")
+    parser.add_argument("--debug", action="store_true", help="Show debug info")
+
+    args = parser.parse_args()
+
+    config = load_config()
+
+    if args.debug:
+        print(
+            f"Creating room name={args.name!r} alias={args.alias!r} "
+            f"preset={args.preset} invite={args.invite}",
+            file=sys.stderr,
+        )
+
+    result = create_room(
+        config,
+        args.name,
+        alias=args.alias,
+        topic=args.topic,
+        invite=args.invite,
+        preset=args.preset,
+    )
+
+    if "error" in result:
+        if args.json:
+            print(json.dumps(result))
+        else:
+            print(f"Error: {result['error']}", file=sys.stderr)
+        sys.exit(1)
+
+    if args.json:
+        print(json.dumps(result))
+    elif args.quiet:
+        print(result.get("room_id", ""))
+    else:
+        print(f"Room created: {result.get('room_id')}")
+        if args.alias:
+            # Room aliases live on the user's server_name (from user_id),
+            # not the homeserver URL — these differ when the homeserver is
+            # reached via a delegated/well-known domain (e.g. homeserver
+            # https://matrix.example.com but server_name example.com).
+            user_id = config.get("user_id")
+            if not user_id:
+                whoami = matrix_request(config, "GET", "/account/whoami")
+                user_id = whoami.get("user_id")
+            if user_id:
+                server_name = user_id.split(":", 1)[-1]
+                print(f"Alias: #{args.alias}:{server_name}")
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/matrix-communication/scripts/matrix-invite.py
+++ b/skills/matrix-communication/scripts/matrix-invite.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.10"
+# dependencies = []
+# ///
+"""Invite a user to a Matrix room.
+
+Usage:
+    matrix-invite.py ROOM USER_ID [OPTIONS]
+    matrix-invite.py --help
+
+Arguments:
+    ROOM        Room identifier. Supports multiple formats:
+                - Room ID: !abc123xyz (direct, fastest)
+                - Room alias: #room:server (resolved via directory)
+                - Room name: "agent-work" (looked up from joined rooms)
+    USER_ID     Full Matrix user ID to invite (e.g. @jane.doe:netresearch.de)
+
+Options:
+    --json      Output as JSON
+    --quiet     Minimal output
+    --debug     Show debug information
+    --help      Show this help
+
+Examples:
+    # Invite by room name
+    matrix-invite.py "LSB Project" '@jane.doe:netresearch.de'
+
+    # Invite by room ID
+    matrix-invite.py '!abc123:netresearch.de' '@jane.doe:netresearch.de'
+"""
+
+import json
+import os
+import sys
+
+# Add script directory to path for _lib imports
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from _lib import (
+    load_config,
+    matrix_request,
+    resolve_room_cli,
+)
+
+sys.stdout.reconfigure(line_buffering=True)
+sys.stderr.reconfigure(line_buffering=True)
+
+
+def invite_user(config: dict, room_id: str, user_id: str) -> dict:
+    """Invite a user to a Matrix room.
+
+    Args:
+        config: Matrix config with homeserver and access_token
+        room_id: Room ID to invite to
+        user_id: Full Matrix user ID (e.g. @user:server)
+
+    Returns:
+        Empty dict on success (per Matrix spec), or dict with 'error' on failure
+    """
+    return matrix_request(
+        config, "POST", f"/rooms/{room_id}/invite", {"user_id": user_id}
+    )
+
+
+def main():
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Invite a user to a Matrix room")
+    parser.add_argument("room", help="Room ID (!id), alias (#room:server), or name")
+    parser.add_argument("user_id", help="Matrix user ID to invite (@user:server)")
+    parser.add_argument("--json", action="store_true", help="Output as JSON")
+    parser.add_argument("--quiet", "-q", action="store_true", help="Minimal output")
+    parser.add_argument("--debug", action="store_true", help="Show debug info")
+
+    args = parser.parse_args()
+
+    config = load_config()
+    room_id = resolve_room_cli(config, args.room, args.json, args.debug)
+
+    if args.debug:
+        print(f"Inviting {args.user_id} to {room_id}", file=sys.stderr)
+
+    result = invite_user(config, room_id, args.user_id)
+
+    if "error" in result:
+        if args.json:
+            print(json.dumps(result))
+        else:
+            print(f"Error: {result['error']}", file=sys.stderr)
+        sys.exit(1)
+
+    if args.json:
+        print(json.dumps({"room_id": room_id, "user_id": args.user_id}))
+    elif args.quiet:
+        print(room_id)
+    else:
+        print(f"Invited {args.user_id} to {room_id}")
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/matrix-communication/scripts/matrix-power-level.py
+++ b/skills/matrix-communication/scripts/matrix-power-level.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.10"
+# dependencies = []
+# ///
+"""Show or set a user's power level in a Matrix room.
+
+Usage:
+    matrix-power-level.py ROOM --show
+    matrix-power-level.py ROOM --get USER_ID
+    matrix-power-level.py ROOM --set USER_ID LEVEL
+    matrix-power-level.py --help
+
+Arguments:
+    ROOM        Room identifier. Supports multiple formats:
+                - Room ID: !abc123xyz (direct, fastest)
+                - Room alias: #room:server (resolved via directory)
+                - Room name: "agent-work" (looked up from joined rooms)
+
+Options:
+    --show            Print the full m.room.power_levels event content
+    --get USER_ID     Print USER_ID's current power level (falls back to
+                      users_default if not listed explicitly)
+    --set USER_ID LEVEL
+                      Set USER_ID's power level to LEVEL (integer, commonly
+                      0=user, 50=moderator, 100=admin — any int is valid)
+    --json            Output as JSON
+    --quiet           Minimal output
+    --debug           Show debug information
+    --help            Show this help
+
+Power levels are a single room state event: setting one user's level requires
+reading the whole event, changing just that user's entry, and writing the
+whole event back (a PUT replaces the entire content — there is no merge on
+the server side). --set does this GET-modify-PUT for you. The acting user
+(the bot) needs a power level >= the level being granted and >= the target's
+current level, otherwise the homeserver rejects the change with M_FORBIDDEN.
+
+On newer room versions the room creator has implicit, permanent authority
+and must NOT appear in content.users — the server rejects an attempt to set
+the creator's own level with "Creator user must not appear in content.users".
+This is expected: don't try to promote/demote the creator, only other members.
+
+Examples:
+    # Inspect current power levels before changing anything
+    matrix-power-level.py "LSB Project" --show
+
+    # Check one user's level
+    matrix-power-level.py "LSB Project" --get '@jane.doe:netresearch.de'
+
+    # Promote a user to moderator
+    matrix-power-level.py "LSB Project" --set '@jane.doe:netresearch.de' 50
+
+    # Promote a user to admin
+    matrix-power-level.py '!abc123:netresearch.de' --set '@jane.doe:netresearch.de' 100
+"""
+
+import json
+import os
+import sys
+
+# Add script directory to path for _lib imports
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from _lib import (
+    load_config,
+    matrix_request,
+    resolve_room_cli,
+)
+
+sys.stdout.reconfigure(line_buffering=True)
+sys.stderr.reconfigure(line_buffering=True)
+
+
+def get_power_levels(config: dict, room_id: str) -> dict:
+    """Fetch the current m.room.power_levels state event content.
+
+    Returns:
+        The power_levels content dict, or a dict with 'error' on failure.
+    """
+    return matrix_request(config, "GET", f"/rooms/{room_id}/state/m.room.power_levels/")
+
+
+def set_power_level(config: dict, room_id: str, user_id: str, level: int) -> dict:
+    """Set a single user's power level via GET-modify-PUT.
+
+    The power_levels state event has one state key (empty string) holding
+    the whole permission model. Setting one user's level means fetching the
+    current content, mutating its "users" dict in place, and PUTting the
+    complete object back — a partial PUT would silently wipe every other
+    key (events, state_default, ban/kick/redact/invite, other users' levels).
+    """
+    content = get_power_levels(config, room_id)
+    if "error" in content:
+        return content
+
+    content.setdefault("users", {})
+    previous = content["users"].get(user_id, content.get("users_default", 0))
+    content["users"][user_id] = level
+
+    result = matrix_request(
+        config, "PUT", f"/rooms/{room_id}/state/m.room.power_levels/", content
+    )
+    if "error" in result:
+        return result
+
+    return {
+        "room_id": room_id,
+        "user_id": user_id,
+        "previous": previous,
+        "level": level,
+    }
+
+
+def main():
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description="Show or set a user's power level in a Matrix room"
+    )
+    parser.add_argument("room", help="Room ID (!id), alias (#room:server), or name")
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument(
+        "--show", action="store_true", help="Print the full power_levels event"
+    )
+    group.add_argument(
+        "--get", metavar="USER_ID", help="Print USER_ID's current power level"
+    )
+    group.add_argument(
+        "--set",
+        nargs=2,
+        metavar=("USER_ID", "LEVEL"),
+        help="Set USER_ID's power level to LEVEL",
+    )
+    parser.add_argument("--json", action="store_true", help="Output as JSON")
+    parser.add_argument("--quiet", "-q", action="store_true", help="Minimal output")
+    parser.add_argument("--debug", action="store_true", help="Show debug info")
+
+    args = parser.parse_args()
+
+    config = load_config()
+    room_id = resolve_room_cli(config, args.room, args.json, args.debug)
+
+    if args.show:
+        result = get_power_levels(config, room_id)
+        if "error" in result:
+            if args.json:
+                print(json.dumps(result))
+            else:
+                print(f"Error: {result['error']}", file=sys.stderr)
+            sys.exit(1)
+        print(json.dumps(result, indent=None if args.quiet else 2))
+        return
+
+    if args.get:
+        result = get_power_levels(config, room_id)
+        if "error" in result:
+            if args.json:
+                print(json.dumps(result))
+            else:
+                print(f"Error: {result['error']}", file=sys.stderr)
+            sys.exit(1)
+        level = result.get("users", {}).get(args.get, result.get("users_default", 0))
+        if args.json:
+            print(json.dumps({"room_id": room_id, "user_id": args.get, "level": level}))
+        elif args.quiet:
+            print(level)
+        else:
+            print(f"{args.get} in {room_id}: {level}")
+        return
+
+    # --set
+    user_id, level_str = args.set
+    try:
+        level = int(level_str)
+    except ValueError:
+        msg = f"LEVEL must be an integer, got {level_str!r}"
+        if args.json:
+            print(json.dumps({"error": msg}))
+        else:
+            print(f"Error: {msg}", file=sys.stderr)
+        sys.exit(1)
+
+    if args.debug:
+        print(f"Setting {user_id} to power level {level} in {room_id}", file=sys.stderr)
+
+    result = set_power_level(config, room_id, user_id, level)
+
+    if "error" in result:
+        if args.json:
+            print(json.dumps(result))
+        else:
+            print(f"Error: {result['error']}", file=sys.stderr)
+        sys.exit(1)
+
+    if args.json:
+        print(json.dumps(result))
+    elif args.quiet:
+        print(result["level"])
+    else:
+        print(f"{user_id} in {room_id}: {result['previous']} -> {result['level']}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Adds `matrix-create-room.py`, `matrix-invite.py`, and `matrix-power-level.py` to `matrix-communication` — the skill previously only had scripts for messaging/reading in rooms that already exist, not creating or managing them.
- `matrix-power-level.py` supports `--show` (inspect), `--get USER_ID` (query one user), and `--set USER_ID LEVEL` (GET-modify-PUT against `m.room.power_levels`, preserving every other key so it can't silently wipe the room's permission model).
- Documents a homeserver quirk found via live testing: on newer room versions the creator cannot appear in `content.users` at all — the server rejects an attempt to set the creator's own power level.
- Adds 3 new evals (create-room, invite-to-room, promote-to-moderator) following the existing one-eval-per-capability convention.
- Updates `references/api-reference.md`, `SKILL.md` (net +46 words after trimming), `README.md`, and `CHANGELOG.md` (Unreleased).

## Test plan

- [x] `ruff format --check` / `ruff check` pass on all 3 new scripts
- [x] markdownlint passes against this repo's actual CI-equivalent config (no `.markdownlint.jsonc` present, so MD013/024/033/036/040/041/060 are disabled)
- [x] Live-tested against `matrix.netresearch.de` in a throwaway test room: room creation (with and without alias), `--show`/`--get`/`--set` power levels (confirmed unrelated keys survive the PUT), invite (confirmed via `joined_members`) — all test rooms cleaned up afterward
- [x] Reviewed via the `skill-creator` skill per repo convention before release