### PR TITLE
chore(release): v1.27.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "matrix-communication",
-  "version": "1.26.0",
+  "version": "1.27.0",
   "description": "Agentic Skills for Matrix: client-side chat (matrix-communication), Synapse homeserver administration (matrix-administration), and structured announcement composition (matrix-announcement). Works with any Matrix/Synapse homeserver.",
   "author": {
     "name": "Netresearch DTT GmbH",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,11 @@ For the canonical narrative version of each release (rewritten after CI publishe
 
 ## [Unreleased]
 
+## [1.27.0] - 2026-07-26
+
 ### Added
 
-- matrix-communication: room management — `matrix-create-room.py` (create, with optional alias/topic/initial invites), `matrix-invite.py`, and `matrix-power-level.py` (`--show`/`--get`/`--set`, GET-modify-PUT against `m.room.power_levels`).
+- matrix-communication: room management — `matrix-create-room.py` (create, with optional alias/topic/initial invites), `matrix-invite.py`, and `matrix-power-level.py` (`--show`/`--get`/`--set`, GET-modify-PUT against `m.room.power_levels`) ([#59](https://github.com/netresearch/matrix-skill/pull/59)).
 
 ## [1.25.4] - 2026-07-13
 

--- a/skills/matrix-administration/SKILL.md
+++ b/skills/matrix-administration/SKILL.md
@@ -5,7 +5,7 @@ license: "(MIT AND CC-BY-SA-4.0). See LICENSE-MIT and LICENSE-CC-BY-SA-4.0"
 compatibility: "python3 (stdlib only) + a Matrix access token belonging to a Synapse server-admin user. Optional: graphviz `dot` for SVG. Synapse 1.x with admin API enabled."
 metadata:
   author: Netresearch DTT GmbH
-  version: "1.26.0"
+  version: "1.27.0"
   repository: https://github.com/netresearch/matrix-skill
 allowed-tools: Bash(python3:*) Bash(uv:*) Bash(dot:*) Read Write
 ---

--- a/skills/matrix-announcement/SKILL.md
+++ b/skills/matrix-announcement/SKILL.md
@@ -5,7 +5,7 @@ license: "(MIT AND CC-BY-SA-4.0). See LICENSE-MIT and LICENSE-CC-BY-SA-4.0"
 compatibility: "Pairs with matrix-communication for sending. Optional: Chromium for HTML-card rendering."
 metadata:
   author: Netresearch DTT GmbH
-  version: "1.26.0"
+  version: "1.27.0"
   repository: https://github.com/netresearch/matrix-skill
 allowed-tools: Bash(chromium:*) Bash(curl:*) Bash(jq:*) Read Write
 ---

--- a/skills/matrix-communication/SKILL.md
+++ b/skills/matrix-communication/SKILL.md
@@ -5,7 +5,7 @@ license: "(MIT AND CC-BY-SA-4.0). See LICENSE-MIT and LICENSE-CC-BY-SA-4.0"
 compatibility: "Requires python3, uv. Matrix homeserver access."
 metadata:
   author: Netresearch DTT GmbH
-  version: "1.26.0"
+  version: "1.27.0"
   repository: https://github.com/netresearch/matrix-skill
 allowed-tools: Bash(python3:*) Bash(uv:*) Read Write
 ---


### PR DESCRIPTION
## Summary

- Bumps plugin.json and all three SKILL.md files (matrix-communication, matrix-administration, matrix-announcement) from 1.26.0 to 1.27.0 in lockstep, per repo convention.
- Moves the Unreleased changelog entry under `## [1.27.0] - 2026-07-26`, documenting the matrix-communication room management scripts from #59.

## Test plan

- [x] All three SKILL.md `metadata.version` fields match plugin.json