### PR TITLE
fix(doctor): verify the token against the homeserver instead of just parsing it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,30 @@ For the canonical narrative version of each release (rewritten after CI publishe
 
 ## [Unreleased]
 
+### Fixed
+
+- **`matrix-doctor.py` reported a healthy setup for a token the homeserver
+  rejects.** `check_config` only proved that `config.json` exists, parses, and
+  carries `homeserver` and `user_id` — it never asked the homeserver anything, so
+  an expired or revoked token still produced `[OK] config` and `All checks
+  passed! Matrix Skill is ready to use.` while every authenticated call returned
+  HTTP 401 `M_UNKNOWN_TOKEN`. A green doctor beside a 401 sends you looking for
+  the problem everywhere except at the credential; worse, when the doctor's
+  verdict stands in as evidence that something is fine, a dead token reads as
+  "nothing to see" instead of "could not verify".
+
+  A new `token` row asks `GET /_matrix/client/v3/account/whoami` and reports
+  three states: accepted (and belonging to the configured `user_id`), rejected,
+  or not verified. Not-verified renders as `[??]`, never `OK` — no token in the
+  config is normal for E2EE use, `--offline` skips the call, and an unreachable
+  homeserver is a missing answer. The summary line now names what it could not
+  verify instead of claiming everything passed.
+
+### Added
+
+- **`matrix-doctor.py --offline`** skips the token check's homeserver call for
+  air-gapped or CI runs; the row then reads "not verified" rather than OK.
+
 ## [1.27.1] - 2026-07-26
 
 ### Added

--- a/skills/matrix-communication/SKILL.md
+++ b/skills/matrix-communication/SKILL.md
@@ -61,6 +61,7 @@ uv run ${CLAUDE_SKILL_DIR}/scripts/matrix-key-backup.py --recovery-key "EsTj ...
 
 # Health check (uses python3, not uv run)
 python3 ${CLAUDE_SKILL_DIR}/scripts/matrix-doctor.py --install
+python3 ${CLAUDE_SKILL_DIR}/scripts/matrix-doctor.py --offline   # no homeserver call; token reads 'not verified'
 ```
 
 ## Script Selection
@@ -93,6 +94,7 @@ Other: `matrix-rooms.py`, `matrix-resolve.py`, `matrix-create-room.py`, `matrix-
 | `[Unable to decrypt]` | First: `uv run ${CLAUDE_SKILL_DIR}/scripts/matrix-fetch-keys.py ROOM --sync-time 60` (requests keys from other devices, no recovery key needed); fallback: `uv run ${CLAUDE_SKILL_DIR}/scripts/matrix-key-backup.py --recovery-key "..." --import-keys` |
 | `libolm not found` | Linux: `apt install libolm-dev`; macOS 26+ unsupported (see `references/setup-guide.md`) |
 | `matrix-nio not found` | `python3 ${CLAUDE_SKILL_DIR}/scripts/matrix-doctor.py --install` |
+| `M_UNKNOWN_TOKEN` / HTTP 401 | The config token expired or was revoked. `matrix-doctor.py` reports it as `[FAIL] token`; log in again and replace it in the config |
 | `Invalid password` | Use env var: `MATRIX_PASSWORD="pass" uv run ...` |
 | `signature failed` | Dedicated device via `matrix-e2ee-setup.py` |
 

--- a/skills/matrix-communication/references/setup-guide.md
+++ b/skills/matrix-communication/references/setup-guide.md
@@ -12,7 +12,25 @@ python3 skills/matrix-communication/scripts/matrix-doctor.py
 
 # Auto-install missing dependencies
 python3 skills/matrix-communication/scripts/matrix-doctor.py --install
+
+# Skip the homeserver call (air-gapped / CI): the token row then reads
+# 'not verified' instead of OK, and the summary says so
+python3 skills/matrix-communication/scripts/matrix-doctor.py --offline
 ```
+
+The `token` row asks the homeserver (`GET /_matrix/client/v3/account/whoami`)
+whether the config token actually works, because a revoked or expired token
+leaves the config file perfectly well-formed. It has three outcomes:
+
+| row | meaning |
+| --- | --- |
+| `[OK] token` | the homeserver accepted it and it belongs to the configured `user_id` |
+| `[FAIL] token` | the homeserver rejected it (HTTP 401 `M_UNKNOWN_TOKEN`) — log in again and replace it |
+| `[??] token` | nothing was verified: no token in the config (normal for E2EE, which uses the credentials store), `--offline`, or the homeserver was unreachable |
+
+`[??]` is deliberately not `OK`: the summary then reads "Checks passed, except
+token — could not be verified" rather than "All checks passed", so a passing
+doctor never implies a working credential.
 
 **Required for E2EE:**
 - `matrix-nio[e2e]` - Matrix client library with encryption support

--- a/skills/matrix-communication/scripts/matrix-doctor.py
+++ b/skills/matrix-communication/scripts/matrix-doctor.py
@@ -23,12 +23,14 @@ Options:
 import json
 import os
 import shutil
+import socket
 import subprocess
 import sys
 
 # Add script directory to path for _lib imports
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
+from _lib import http
 from _lib.config import get_config_path
 from _lib.e2ee import get_store_path
 
@@ -164,54 +166,40 @@ def check_token(config: dict, offline: bool = False) -> tuple[bool | None, str]:
             "No token in config (normal for E2EE - those scripts use the credentials store)",
         )
 
-    homeserver = str(config.get("homeserver", "")).rstrip("/")
-    if not homeserver:
+    if not config.get("homeserver"):
         return None, "No homeserver in config - cannot verify the token"
     if offline:
         return None, "Not verified (--offline): a parseable token is not a working one"
 
-    import urllib.error
-    import urllib.parse
-    import urllib.request
-
-    # Same guard as matrix-administration's _lib/admin_http._require_http_scheme:
-    # urllib honours file:// and friends, so a homeserver value that is not
-    # http(s) would turn a health check into a local file read.
-    scheme = urllib.parse.urlparse(homeserver).scheme
-    if scheme not in ("http", "https"):
-        return (
-            None,
-            f"Refusing to verify the token against scheme {scheme!r}; only http/https allowed",
-        )
-
     which = "admin_token" if config.get("admin_token") else "access_token"
-    req = urllib.request.Request(
-        f"{homeserver}/_matrix/client/v3/account/whoami",
-        headers={"Authorization": f"Bearer {token}"},
-    )
+
+    # Delegate to _lib.http.matrix_request rather than hand-rolling urllib: it
+    # already carries the http(s) scheme allow-list (urllib honours file://, so
+    # an unguarded homeserver value would turn a health check into a local file
+    # read), the Matrix error parsing, and the IPv4 retry for hosts with dead
+    # IPv6 routes. It has no timeout of its own, and a doctor must not hang on a
+    # black-holed host, so the socket default is scoped around the call.
+    request_config = {**config, "access_token": token}
+    old_timeout = socket.getdefaulttimeout()
+    socket.setdefaulttimeout(5)
     try:
-        # scheme restricted to http/https above
-        with urllib.request.urlopen(req, timeout=5) as resp:
-            whoami = json.load(resp)
-    except urllib.error.HTTPError as exc:
-        body = exc.read().decode(errors="replace")[:200]
-        errcode = ""
-        try:
-            errcode = json.loads(body).get("errcode", "")
-        except (json.JSONDecodeError, AttributeError):
-            pass
-        if exc.code in (401, 403):
-            hint = f" ({errcode})" if errcode else ""
+        whoami = http.matrix_request(request_config, "GET", "/account/whoami")
+    except ValueError as exc:  # scheme rejected by the allow-list
+        return None, str(exc)
+    except Exception as exc:  # noqa: BLE001  # intentional fail-soft: unknown, never reported as OK
+        return None, f"Could not verify {which}: {exc}"
+    finally:
+        socket.setdefaulttimeout(old_timeout)
+
+    if "error" in whoami:
+        errcode = whoami.get("errcode") or ""
+        if errcode in ("M_UNKNOWN_TOKEN", "M_MISSING_TOKEN", "M_FORBIDDEN"):
             return (
                 False,
-                f"{which} rejected by the homeserver: HTTP {exc.code}{hint} - log in again to mint a new one",
+                f"{which} rejected by the homeserver ({errcode}) - log in again to mint a new one",
             )
-        return (
-            None,
-            f"Could not verify {which}: HTTP {exc.code} {errcode or body}".strip(),
-        )
-    except Exception as exc:  # noqa: BLE001  # intentional fail-soft: unknown, never reported as OK
-        return None, f"Could not reach {homeserver} to verify {which}: {exc}"
+        detail = f"{errcode}: {whoami['error']}" if errcode else str(whoami["error"])
+        return None, f"Could not verify {which} - {detail}"[:200]
 
     served = whoami.get("user_id", "")
     configured = config.get("user_id", "")

--- a/skills/matrix-communication/scripts/matrix-doctor.py
+++ b/skills/matrix-communication/scripts/matrix-doctor.py
@@ -171,7 +171,18 @@ def check_token(config: dict, offline: bool = False) -> tuple[bool | None, str]:
         return None, "Not verified (--offline): a parseable token is not a working one"
 
     import urllib.error
+    import urllib.parse
     import urllib.request
+
+    # Same guard as matrix-administration's _lib/admin_http._require_http_scheme:
+    # urllib honours file:// and friends, so a homeserver value that is not
+    # http(s) would turn a health check into a local file read.
+    scheme = urllib.parse.urlparse(homeserver).scheme
+    if scheme not in ("http", "https"):
+        return (
+            None,
+            f"Refusing to verify the token against scheme {scheme!r}; only http/https allowed",
+        )
 
     which = "admin_token" if config.get("admin_token") else "access_token"
     req = urllib.request.Request(
@@ -179,7 +190,8 @@ def check_token(config: dict, offline: bool = False) -> tuple[bool | None, str]:
         headers={"Authorization": f"Bearer {token}"},
     )
     try:
-        with urllib.request.urlopen(req, timeout=5) as resp:  # noqa: S310  # scheme comes from the user's own config
+        # scheme restricted to http/https above
+        with urllib.request.urlopen(req, timeout=5) as resp:
             whoami = json.load(resp)
     except urllib.error.HTTPError as exc:
         body = exc.read().decode(errors="replace")[:200]

--- a/skills/matrix-communication/scripts/matrix-doctor.py
+++ b/skills/matrix-communication/scripts/matrix-doctor.py
@@ -9,13 +9,14 @@ Checks all dependencies and configuration, installs missing packages,
 and reports on E2EE setup status.
 
 Usage:
-    matrix-doctor.py [--install] [--json] [--quiet]
+    matrix-doctor.py [--install] [--json] [--quiet] [--offline]
     matrix-doctor.py --help
 
 Options:
     --install   Automatically install missing dependencies
     --json      Output as JSON
     --quiet     Only show errors
+    --offline   Skip the token check's homeserver call (reports 'not verified')
     --help      Show this help
 """
 
@@ -140,6 +141,76 @@ def check_config() -> tuple[bool, str, dict]:
         return False, f"Error reading config: {e}", {}
 
 
+def check_token(config: dict, offline: bool = False) -> tuple[bool | None, str]:
+    """Ask the homeserver whether the config token actually works.
+
+    ``check_config`` only proves the file parses. A token that has expired or been
+    revoked leaves the config perfectly well-formed, so without this the doctor
+    reports a healthy setup while every authenticated call returns HTTP 401
+    ``M_UNKNOWN_TOKEN`` - and a green doctor sends you looking for the problem
+    everywhere except at the credential.
+
+    Returns ``(True, msg)`` only when the homeserver confirmed the token,
+    ``(False, msg)`` when it rejected it, and ``(None, msg)`` when there is
+    nothing to verify or the answer is unknown. Unknown is never OK: no token in
+    the config is normal for E2EE use (those scripts authenticate from the
+    credentials store), and an unreachable homeserver is a missing answer, not a
+    passing one.
+    """
+    token = config.get("admin_token") or config.get("access_token")
+    if not token:
+        return (
+            None,
+            "No token in config (normal for E2EE - those scripts use the credentials store)",
+        )
+
+    homeserver = str(config.get("homeserver", "")).rstrip("/")
+    if not homeserver:
+        return None, "No homeserver in config - cannot verify the token"
+    if offline:
+        return None, "Not verified (--offline): a parseable token is not a working one"
+
+    import urllib.error
+    import urllib.request
+
+    which = "admin_token" if config.get("admin_token") else "access_token"
+    req = urllib.request.Request(
+        f"{homeserver}/_matrix/client/v3/account/whoami",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=5) as resp:  # noqa: S310  # scheme comes from the user's own config
+            whoami = json.load(resp)
+    except urllib.error.HTTPError as exc:
+        body = exc.read().decode(errors="replace")[:200]
+        errcode = ""
+        try:
+            errcode = json.loads(body).get("errcode", "")
+        except (json.JSONDecodeError, AttributeError):
+            pass
+        if exc.code in (401, 403):
+            hint = f" ({errcode})" if errcode else ""
+            return (
+                False,
+                f"{which} rejected by the homeserver: HTTP {exc.code}{hint} - log in again to mint a new one",
+            )
+        return (
+            None,
+            f"Could not verify {which}: HTTP {exc.code} {errcode or body}".strip(),
+        )
+    except Exception as exc:  # noqa: BLE001  # intentional fail-soft: unknown, never reported as OK
+        return None, f"Could not reach {homeserver} to verify {which}: {exc}"
+
+    served = whoami.get("user_id", "")
+    configured = config.get("user_id", "")
+    if configured and served and served != configured:
+        return (
+            False,
+            f"{which} is valid but belongs to {served}, while the config says {configured}",
+        )
+    return True, f"{which} valid for {served or configured}"
+
+
 def check_e2ee_setup() -> tuple[bool, str]:
     """Check E2EE device setup status."""
     store_dir = get_store_path()
@@ -189,6 +260,11 @@ def main():
     )
     parser.add_argument("--json", action="store_true", help="Output as JSON")
     parser.add_argument("--quiet", "-q", action="store_true", help="Only show errors")
+    parser.add_argument(
+        "--offline",
+        action="store_true",
+        help="Skip the token check's homeserver call; it then reports 'not verified', never OK",
+    )
 
     args = parser.parse_args()
 
@@ -197,6 +273,7 @@ def main():
         "matrix_nio": {"ok": False, "message": "", "critical": True},
         "libolm": {"ok": False, "message": "", "critical": False},
         "config": {"ok": False, "message": "", "critical": True},
+        "token": {"ok": False, "message": "", "critical": False},
         "e2ee_setup": {"ok": False, "message": "", "critical": False},
     }
 
@@ -221,9 +298,15 @@ def main():
     checks["libolm"]["message"] = olm_msg
 
     # Check config
-    config_ok, config_msg, _config_data = check_config()
+    config_ok, config_msg, config_data = check_config()
     checks["config"]["ok"] = config_ok
     checks["config"]["message"] = config_msg
+
+    # Check the token against the homeserver (a parseable token is not a working one)
+    token_ok, token_msg = check_token(config_data, offline=args.offline)
+    checks["token"]["ok"] = token_ok is True
+    checks["token"]["unknown"] = token_ok is None
+    checks["token"]["message"] = token_msg
 
     # Check E2EE setup
     e2ee_ok, e2ee_msg = check_e2ee_setup()
@@ -255,14 +338,23 @@ def main():
         print("=" * 60)
         print()
 
+    unverified = []
+
     for name, check in checks.items():
         if name == "install_messages":
             continue
 
-        icon = "OK" if check["ok"] else "FAIL"
+        # Three states, not two: a check that could not be answered must not
+        # render as OK (it would claim a verification that never happened) and
+        # must not render as FAIL either (it is not a finding).
+        if check.get("unknown"):
+            icon = "??"
+            unverified.append(name)
+        else:
+            icon = "OK" if check["ok"] else "FAIL"
         critical = " (required)" if check.get("critical") else ""
 
-        if not check["ok"]:
+        if not check["ok"] and not check.get("unknown"):
             all_ok = False
             if check.get("critical"):
                 critical_ok = False
@@ -276,8 +368,12 @@ def main():
     if not args.quiet:
         print("=" * 60)
 
-    if all_ok:
+    if all_ok and not unverified:
         print("All checks passed! Matrix Skill is ready to use.")
+    elif all_ok:
+        print(
+            f"Checks passed, except {', '.join(unverified)} - could not be verified (see above)."
+        )
     elif critical_ok:
         print("Core functionality OK. Some optional features may be limited.")
     else:
@@ -292,6 +388,8 @@ def main():
             print("  - Set up Matrix: see SKILL.md Setup Guide")
         if not checks["e2ee_setup"]["ok"] and checks["config"]["ok"]:
             print("  - Run: matrix-e2ee-setup.py")
+        if not checks["token"]["ok"] and not checks["token"].get("unknown"):
+            print("  - Token rejected: log in again and replace it in the config")
 
     sys.exit(0 if critical_ok else 1)
 


### PR DESCRIPTION
`check_config` proved that `config.json` exists, parses, and carries `homeserver` and `user_id`. It never asked the homeserver anything — so a token that had expired or been revoked still produced:

```text
[OK] config (required)
     Config OK: @user:example.org
...
All checks passed! Matrix Skill is ready to use.
```

while every authenticated call returned:

```json
{"errcode":"M_UNKNOWN_TOKEN","error":"Invalid access token passed.","soft_logout":false}
```

## Why this matters

The doctor is what you run to find out whether the skill works. A green doctor beside a 401 sends you looking for the problem everywhere except at the credential.

It also gets used the other way round: when the doctor's verdict stands in as evidence that something is fine, a dead token reads as "nothing to see here" rather than "could not verify". For an admin-token workflow that difference decides whether an account gets looked at at all — which is how this was found.

## Change

A `token` row asks `GET /_matrix/client/v3/account/whoami` and reports **three** states instead of two:

| row | meaning |
| --- | --- |
| `[OK] token` | the homeserver accepted it, and it belongs to the configured `user_id` |
| `[FAIL] token` | rejected — HTTP 401/403 with the `errcode` surfaced, plus the remedy |
| `[??] token` | nothing was verified |

`[??]` is deliberately **not** `OK`. Three ways to land there, none of them a finding and none of them a pass:

- **no token in the config** — normal for E2EE use, where the scripts authenticate from the credentials store; the field is documented as optional, so requiring it would break working setups
- **`--offline`** (new flag) — for air-gapped or CI runs
- **homeserver unreachable** — a missing answer, not a passing one

The summary line now names what it could not verify:

```text
Checks passed, except token - could not be verified (see above).
```

`whoami` also catches a token that is valid but belongs to a *different* account than the config claims.

## Exit codes unchanged, on purpose

The row is non-critical, so a stale config token nobody uses does not start failing automation that shells out to the doctor. The visible `FAIL` row plus an honest summary is the fix here; changing exit semantics is a separate decision, and mixing it in would surprise anyone gating on the exit code.

## Verified

Against a live homeserver, all four states:

| config | row | summary | exit |
| --- | --- | --- | --- |
| valid token | `[OK] token` | All checks passed | 0 |
| revoked token | `[FAIL] token … HTTP 401 (M_UNKNOWN_TOKEN)` | no longer "All checks passed" | 0 |
| no token | `[??] token` | "except token — could not be verified" | 0 |
| `--offline` | `[??] token` | "except token — could not be verified" | 0 |

```text
ruff check   -> All checks passed
ruff format  -> clean
markdownlint -> 0 issues
check-plugin-version.sh -> ok
verify-harness.sh --status -> Level 3 (Enforced) COMPLETE
```

## Also in this PR

- `--offline` documented in the script docstring, `SKILL.md` and `references/setup-guide.md`, including the three-state table
- an `M_UNKNOWN_TOKEN` / HTTP 401 row in the SKILL.md troubleshooting table
- `CHANGELOG.md` under `[Unreleased]` — no version bump; that belongs to a release
