### PR TITLE
chore(release): v1.28.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "matrix-communication",
-  "version": "1.27.1",
+  "version": "1.28.0",
   "description": "Agentic Skills for Matrix: client-side chat (matrix-communication), Synapse homeserver administration (matrix-administration), and structured announcement composition (matrix-announcement). Works with any Matrix/Synapse homeserver.",
   "author": {
     "name": "Netresearch DTT GmbH",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ For the canonical narrative version of each release (rewritten after CI publishe
 
 ## [Unreleased]
 
+## [1.28.0] - 2026-08-08
+
 ### Fixed
 
 - **`matrix-doctor.py` reported a healthy setup for a token the homeserver
@@ -98,7 +100,6 @@ For the canonical narrative version of each release (rewritten after CI publishe
 ### Fixed
 
 ### Removed
-
 
 ## [1.23.0] - 2026-05-15
 

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "matrix-communication",
-  "version": "1.27.1",
+  "version": "1.28.0",
   "description": "Agentic Skills for Matrix: client-side chat (matrix-communication), Synapse homeserver administration (matrix-administration), and structured announcement composition (matrix-announcement). Works with any Matrix/Synapse homeserver.",
   "author": {
     "name": "Netresearch DTT GmbH",

--- a/skills/matrix-administration/SKILL.md
+++ b/skills/matrix-administration/SKILL.md
@@ -5,7 +5,7 @@ license: "(MIT AND CC-BY-SA-4.0). See LICENSE-MIT and LICENSE-CC-BY-SA-4.0"
 compatibility: "python3 (stdlib only) + a Matrix access token belonging to a Synapse server-admin user. Optional: graphviz `dot` for SVG. Synapse 1.x with admin API enabled."
 metadata:
   author: Netresearch DTT GmbH
-  version: "1.27.1"
+  version: "1.28.0"
   repository: https://github.com/netresearch/matrix-skill
 allowed-tools: Bash(python3:*) Bash(uv:*) Bash(dot:*) Read Write
 ---

--- a/skills/matrix-announcement/SKILL.md
+++ b/skills/matrix-announcement/SKILL.md
@@ -5,7 +5,7 @@ license: "(MIT AND CC-BY-SA-4.0). See LICENSE-MIT and LICENSE-CC-BY-SA-4.0"
 compatibility: "Pairs with matrix-communication for sending. Optional: Chromium for HTML-card rendering."
 metadata:
   author: Netresearch DTT GmbH
-  version: "1.27.1"
+  version: "1.28.0"
   repository: https://github.com/netresearch/matrix-skill
 allowed-tools: Bash(chromium:*) Bash(curl:*) Bash(jq:*) Read Write
 ---

--- a/skills/matrix-communication/SKILL.md
+++ b/skills/matrix-communication/SKILL.md
@@ -5,7 +5,7 @@ license: "(MIT AND CC-BY-SA-4.0). See LICENSE-MIT and LICENSE-CC-BY-SA-4.0"
 compatibility: "Requires python3, uv. Matrix homeserver access."
 metadata:
   author: Netresearch DTT GmbH
-  version: "1.27.1"
+  version: "1.28.0"
   repository: https://github.com/netresearch/matrix-skill
 allowed-tools: Bash(python3:*) Bash(uv:*) Read Write
 ---


### PR DESCRIPTION
Release v1.28.0.

### Added
- Add Agent Plugins 1.0.0 portable manifest (manifest)

### Fixed
- Verify the token against the homeserver instead of just parsing it (doctor)
- Restrict the token check to http/https and drop the unused noqa (doctor)

### Changed
- Reuse _lib.http.matrix_request for the token check (doctor)

Bumped: root `plugin.json`, `.claude-plugin/plugin.json`, every `skills/*/SKILL.md` frontmatter version. Parity verified with `check-version-parity.sh v1.28.0`.

Tag `v1.28.0` follows once this merges.